### PR TITLE
Enable format selection

### DIFF
--- a/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/BuiltInDocFormatsIntegration.java
+++ b/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/BuiltInDocFormatsIntegration.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.docgen.core;
+
+import java.util.List;
+import software.amazon.smithy.docgen.core.writers.MarkdownWriter;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+/**
+ * Applies the built-in {@link DocFormat}s.
+ */
+@SmithyInternalApi
+public class BuiltInDocFormatsIntegration implements DocIntegration {
+    @Override
+    public List<DocFormat> docFormats(DocSettings settings) {
+        return List.of(
+            new DocFormat("markdown", ".md", new MarkdownWriter.Factory())
+        );
+    }
+}

--- a/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/DocFormat.java
+++ b/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/DocFormat.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.docgen.core;
+
+import software.amazon.smithy.codegen.core.SymbolWriter;
+import software.amazon.smithy.docgen.core.writers.DocWriter;
+import software.amazon.smithy.utils.SmithyUnstableApi;
+
+/**
+ * A record containing information about a doc format.
+ *
+ * <p>Use {@link DocIntegration#docFormats} to make new formats available.
+ *
+ * @param name The name of the format. This will be the string that will be set as the
+ *             value of {@code format} in {@link DocSettings}.
+ * @param extension The file extension to use by default for documentation files. This
+ *                  will be set on the {@code Symbol}s automatically by
+ *                  {@link software.amazon.smithy.docgen.core.DocSymbolProvider.FileExtensionDecorator}.
+ * @param writerFactory A factory method for creating writers that write in this
+ *                      format.
+ */
+@SmithyUnstableApi
+public record DocFormat(String name, String extension, SymbolWriter.Factory<DocWriter> writerFactory) {
+}

--- a/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/DocIntegration.java
+++ b/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/DocIntegration.java
@@ -5,6 +5,7 @@
 
 package software.amazon.smithy.docgen.core;
 
+import java.util.List;
 import software.amazon.smithy.codegen.core.SmithyIntegration;
 import software.amazon.smithy.docgen.core.writers.DocWriter;
 import software.amazon.smithy.utils.SmithyUnstableApi;
@@ -20,4 +21,18 @@ import software.amazon.smithy.utils.SmithyUnstableApi;
  */
 @SmithyUnstableApi
 public interface DocIntegration extends SmithyIntegration<DocSettings, DocWriter, DocGenerationContext> {
+
+    /**
+     * Adds {@link DocFormat}s to the list of supported formats.
+     *
+     * <p>When resolving the format implementation, the first format found with a
+     * matching name will be used. Use {@link #priority} to adjust which integration
+     * is seen first.
+     *
+     * @param settings The documentation generation settings.
+     * @return A list of formats to add.
+     */
+    default List<DocFormat> docFormats(DocSettings settings) {
+        return List.of();
+    }
 }

--- a/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/DocSettings.java
+++ b/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/DocSettings.java
@@ -15,18 +15,21 @@ import software.amazon.smithy.utils.SmithyUnstableApi;
  * {@code smithy-build.json} configuration for this plugin.
  *
  * @param service The shape id of the service to generate documentation for.
+ * @param format The format to generate documentation in. The default is markdown.
  */
 @SmithyUnstableApi
-public record DocSettings(ShapeId service) {
+public record DocSettings(ShapeId service, String format) {
 
     /**
      * Settings for documentation generation. These can be set in the
      * {@code smithy-build.json} configuration for this plugin.
      *
      * @param service The shape id of the service to generate documentation for.
+     * @param format The format to generate documentation in. The default is markdown.
      */
     public DocSettings {
         Objects.requireNonNull(service);
+        Objects.requireNonNull(format);
     }
 
     /**
@@ -36,6 +39,9 @@ public record DocSettings(ShapeId service) {
      * @return loaded settings based on the given node.
      */
     public static DocSettings from(ObjectNode pluginSettings) {
-        return new DocSettings(pluginSettings.expectStringMember("service").expectShapeId());
+        return new DocSettings(
+            pluginSettings.expectStringMember("service").expectShapeId(),
+            pluginSettings.getStringMemberOrDefault("format", "markdown")
+        );
     }
 }

--- a/smithy-docgen-core/src/main/resources/META-INF/services/software.amazon.smithy.docgen.core.DocIntegration
+++ b/smithy-docgen-core/src/main/resources/META-INF/services/software.amazon.smithy.docgen.core.DocIntegration
@@ -1,0 +1,1 @@
+software.amazon.smithy.docgen.core.BuiltInDocFormatsIntegration


### PR DESCRIPTION
This adds the capability to select a doc format and add make new formats available via integrations, with the default format being markdown.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.