### PR TITLE
Support sphinx integration configuration

### DIFF
--- a/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/DocSettings.java
+++ b/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/DocSettings.java
@@ -38,7 +38,7 @@ public record DocSettings(ShapeId service, String format) {
      * @param pluginSettings the {@code ObjectNode} to load settings from.
      * @return loaded settings based on the given node.
      */
-    public static DocSettings from(ObjectNode pluginSettings) {
+    public static DocSettings fromNode(ObjectNode pluginSettings) {
         return new DocSettings(
             pluginSettings.expectStringMember("service").expectShapeId(),
             pluginSettings.getStringMemberOrDefault("format", "sphinx-markdown")

--- a/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/SmithyDocPlugin.java
+++ b/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/SmithyDocPlugin.java
@@ -39,8 +39,6 @@ public final class SmithyDocPlugin implements SmithyBuildPlugin {
     @Override
     public void execute(PluginContext pluginContext) {
         LOGGER.fine("Beginning documentation generation.");
-        DocSettings settings = DocSettings.from(pluginContext.getSettings());
-
         CodegenDirector<DocWriter, DocIntegration, DocGenerationContext, DocSettings> runner
                 = new CodegenDirector<>();
 
@@ -48,7 +46,7 @@ public final class SmithyDocPlugin implements SmithyBuildPlugin {
         runner.integrationClass(DocIntegration.class);
         runner.fileManifest(pluginContext.getFileManifest());
         runner.model(getValidatedModel(pluginContext.getModel()).unwrap());
-        runner.settings(settings);
+        DocSettings settings = runner.settings(DocSettings.class, pluginContext.getSettings());
         runner.service(settings.service());
         runner.performDefaultCodegenTransforms();
         runner.run();


### PR DESCRIPTION
This updates the sphinx integration to have a built-in configuration object that it pulls various settings from. When Smithy 1.41 is released, these will be easily configurable from the smithy-build.json configuration.

This also slightly changes the doc settings's node parsing function so it can be discovered by Smithy's NodeMapper, which lets us use directed codegen's automatic settings mapping, which in turn will automatically handle passing along integration settings when Smithy 1.41 is released.

One more change will be needed when 1.41 is released: the configure method will need to be implemented to actually properly set the settings.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.