### PR TITLE
Generate documentation for operations

### DIFF
--- a/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/DirectedDocGen.java
+++ b/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/DirectedDocGen.java
@@ -12,10 +12,12 @@ import software.amazon.smithy.codegen.core.directed.DirectedCodegen;
 import software.amazon.smithy.codegen.core.directed.GenerateEnumDirective;
 import software.amazon.smithy.codegen.core.directed.GenerateErrorDirective;
 import software.amazon.smithy.codegen.core.directed.GenerateIntEnumDirective;
+import software.amazon.smithy.codegen.core.directed.GenerateOperationDirective;
 import software.amazon.smithy.codegen.core.directed.GenerateResourceDirective;
 import software.amazon.smithy.codegen.core.directed.GenerateServiceDirective;
 import software.amazon.smithy.codegen.core.directed.GenerateStructureDirective;
 import software.amazon.smithy.codegen.core.directed.GenerateUnionDirective;
+import software.amazon.smithy.docgen.core.generators.OperationGenerator;
 import software.amazon.smithy.docgen.core.generators.ServiceGenerator;
 import software.amazon.smithy.docgen.core.generators.StructureGenerator;
 import software.amazon.smithy.utils.SmithyUnstableApi;
@@ -50,6 +52,11 @@ final class DirectedDocGen implements DirectedCodegen<DocGenerationContext, DocS
     @Override
     public void generateStructure(GenerateStructureDirective<DocGenerationContext, DocSettings> directive) {
         new StructureGenerator().accept(directive);
+    }
+
+    @Override
+    public void generateOperation(GenerateOperationDirective<DocGenerationContext, DocSettings> directive) {
+        new OperationGenerator().accept(directive);
     }
 
     @Override

--- a/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/generators/OperationGenerator.java
+++ b/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/generators/OperationGenerator.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.docgen.core.generators;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Consumer;
+import software.amazon.smithy.codegen.core.directed.GenerateOperationDirective;
+import software.amazon.smithy.docgen.core.DocGenerationContext;
+import software.amazon.smithy.docgen.core.DocSettings;
+import software.amazon.smithy.docgen.core.DocSymbolProvider;
+import software.amazon.smithy.docgen.core.generators.MemberGenerator.MemberListingType;
+import software.amazon.smithy.docgen.core.sections.ErrorsSection;
+import software.amazon.smithy.docgen.core.sections.ExampleSection;
+import software.amazon.smithy.docgen.core.sections.ExamplesSection;
+import software.amazon.smithy.docgen.core.sections.ShapeDetailsSection;
+import software.amazon.smithy.docgen.core.sections.ShapeSection;
+import software.amazon.smithy.docgen.core.writers.DocWriter;
+import software.amazon.smithy.docgen.core.writers.DocWriter.ListType;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.traits.ExamplesTrait;
+import software.amazon.smithy.model.traits.ExamplesTrait.Example;
+
+/**
+ * Generates documentation for operations.
+ *
+ * <p>The output of this can be customized in a number of ways. To add details to
+ * or re-write particular sections, register an interceptor with
+ * {@link software.amazon.smithy.docgen.core.DocIntegration#interceptors}. The following
+ * sections are guaranteed to be present:
+ *
+ * <ul>
+ *     <li>{@link ShapeDetailsSection}: Enables adding additional details that are inserted
+ *     directly after the shape's modeled documentation.
+ *
+ *     <li>{@link ShapeSection}: Three versions of this section will appear on the page.
+ *     The first is for the operation shape itself, which enables re-writing or adding
+ *     details to the entire page. The other two are for the input and output shapes,
+ *     which enable modifying the documentation for just the input and output sections.
+ *
+ *     <li>{@link ErrorsSection}: This section will contain a listing of all the errors
+ *     the operation might return. If a synthetic error needs to be applied to an
+ *     operation, it is better to simply add it to the shape with
+ *     {@link software.amazon.smithy.docgen.core.DocIntegration#preprocessModel}.
+ * </ul>
+ *
+ * Additionally, if the operation's input or output shapes have members the following
+ * sections will also be present:
+ *
+ * <ul>
+ *     <li>{@link software.amazon.smithy.docgen.core.sections.MemberSection}: enables
+ *     modifying documentation for an individual input or output member.
+ *
+ *     <li>{@link software.amazon.smithy.docgen.core.sections.ShapeMembersSection}:
+ *     Two versions of this section will appear on the page, one for the operation's
+ *     input shape members and one for the operation's output shape members. These
+ *     enable re-writing or editing those sections.
+ * </ul>
+ *
+ * If the {@code examples} trait has been applied to the operation, it will also have
+ * the following sections:
+ *
+ * <ul>
+ *     <li>{@link ExamplesSection}: enables modifying the entire examples section.
+ *
+ *     <li>{@link ExampleSection}: enables modifying a singular example, including the
+ *     snippets in every discovered language.
+ * </ul>
+ *
+ * <p>To change the intermediate format (e.g. from markdown to restructured text),
+ * a new {@link software.amazon.smithy.docgen.core.DocFormat} needs to be introduced
+ * via {@link software.amazon.smithy.docgen.core.DocIntegration#docFormats}.
+ *
+ * @see MemberGenerator for more details on how member documentation is generated.
+ */
+public class OperationGenerator implements Consumer<GenerateOperationDirective<DocGenerationContext, DocSettings>> {
+    @Override
+    public void accept(GenerateOperationDirective<DocGenerationContext, DocSettings> directive) {
+        var operation = directive.shape();
+        var context = directive.context();
+        var symbol = directive.symbolProvider().toSymbol(operation);
+        context.writerDelegator().useShapeWriter(directive.shape(), writer -> {
+            writer.pushState(new ShapeSection(context, operation));
+            var linkId = symbol.expectProperty(DocSymbolProvider.LINK_ID_PROPERTY, String.class);
+            writer.openHeading(symbol.getName(), linkId);
+            writer.writeShapeDocs(operation, directive.model());
+            writer.injectSection(new ShapeDetailsSection(context, operation));
+
+            new MemberGenerator(context, writer, operation, MemberListingType.INPUT).run();
+            new MemberGenerator(context, writer, operation, MemberListingType.OUTPUT).run();
+
+            writeErrors(context, writer, directive.service(), operation, linkId);
+
+            var examples = operation.getTrait(ExamplesTrait.class).map(ExamplesTrait::getExamples).orElse(List.of());
+            writeExamples(context, writer, operation, examples, linkId);
+
+            writer.closeHeading();
+            writer.popState();
+        });
+    }
+
+    private void writeErrors(
+            DocGenerationContext context,
+            DocWriter writer,
+            ServiceShape service,
+            OperationShape operation,
+            String linkId
+    ) {
+        var errors = operation.getErrors(service);
+        writer.pushState(new ErrorsSection(context, operation));
+        if (!errors.isEmpty()) {
+            writer.openHeading("Errors", linkId + "-errors");
+            writer.write("This operation may return any of the following errors:");
+            writer.openList(ListType.UNORDERED);
+            for (var error : errors) {
+                writer.openListItem(ListType.UNORDERED);
+                writer.write("$R", context.symbolProvider().toSymbol(context.model().expectShape(error)));
+                writer.closeListItem(ListType.UNORDERED);
+            }
+            writer.closeList(ListType.UNORDERED);
+            writer.closeHeading();
+        }
+        writer.popState();
+    }
+
+    private void writeExamples(
+            DocGenerationContext context,
+            DocWriter writer,
+            OperationShape operation,
+            List<Example> examples,
+            String operationLinkId
+    ) {
+        writer.pushState(new ExamplesSection(context, operation, examples));
+        writer.openHeading("Examples", operationLinkId + "-examples");
+        for (var example : examples) {
+            writer.pushState(new ExampleSection(context, operation, example));
+            var linkIdSuffix = example.getTitle().toLowerCase(Locale.ENGLISH).strip().replaceAll("\\s+", "-");
+            writer.openHeading(example.getTitle(), operationLinkId + "-" + linkIdSuffix);
+            example.getDocumentation().ifPresent(writer::writeCommonMark);
+
+            writer.openTabGroup();
+            // TODO: create example writer interface allow integrations to register them
+
+            // This is just a dummy placehodler tab here to exercise tab creation before
+            // there's an interface for it.
+            writer.openCodeTab("Input", "json");
+            writer.write(Node.prettyPrintJson(example.getInput()));
+            writer.closeCodeTab();
+            writer.openCodeTab("Output", "json");
+            writer.write(Node.prettyPrintJson(example.getOutput().orElse(Node.objectNode())));
+            writer.closeCodeTab();
+
+            writer.closeTabGroup();
+
+            writer.closeHeading();
+            writer.popState();
+        }
+        writer.closeHeading();
+        writer.popState();
+    }
+}

--- a/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/integrations/SphinxIntegration.java
+++ b/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/integrations/SphinxIntegration.java
@@ -88,7 +88,8 @@ public final class SphinxIntegration implements DocIntegration {
     private static final List<String> BASE_REQUIREMENTS = List.of(
         "Sphinx==7.2.6",
         "myst-parser==2.0.0",
-        "linkify-it-py==2.0.2"
+        "linkify-it-py==2.0.2",
+        "sphinx-inline-tabs==2023.4.21"
     );
 
     private SphinxSettings settings = SphinxSettings.fromNode(Node.objectNode());
@@ -163,7 +164,10 @@ public final class SphinxIntegration implements DocIntegration {
 
             if (context.docFormat().name().equals(MARKDOWN_FORMAT)) {
                 writer.write("""
-                extensions = ["myst_parser"]
+                extensions = [
+                    "myst_parser",
+                    "sphinx_inline_tabs"
+                ]
                 myst_enable_extensions = [
                     # Makes bare links into actual links
                     "linkify",

--- a/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/sections/ErrorsSection.java
+++ b/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/sections/ErrorsSection.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.docgen.core.sections;
+
+import software.amazon.smithy.docgen.core.DocGenerationContext;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.utils.CodeSection;
+
+/**
+ * Contains a listing of all the errors that an operation might throw, or errors common
+ * to a resource or service.
+ *
+ * <p>To simply add errors to a shape, instead use
+ * {@link software.amazon.smithy.docgen.core.DocIntegration#preprocessModel} to add
+ * them to the shape directly.
+ *
+ * @param context The context used to generate documentation.
+ * @param shape The shape whose errors are being documented.
+ *
+ * @see software.amazon.smithy.docgen.core.generators.OperationGenerator
+ */
+public record ErrorsSection(DocGenerationContext context, Shape shape) implements CodeSection {
+}

--- a/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/sections/ExampleSection.java
+++ b/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/sections/ExampleSection.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.docgen.core.sections;
+
+import software.amazon.smithy.docgen.core.DocGenerationContext;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.traits.ExamplesTrait.Example;
+import software.amazon.smithy.utils.CodeSection;
+
+/**
+ * Generates a single operation example as defined by the {@code examples} trait.
+ *
+ * <p>This modifies the contents of a single example. To modify the entire example
+ * section, use {@link ExamplesSection} instead.
+ *
+ * @param context The context used to generate documentation.
+ * @param operation The operation whose examples are being documented.
+ * @param example The example that will be documented.
+ *
+ * @see ExamplesSection
+ * @see software.amazon.smithy.docgen.core.generators.OperationGenerator
+ */
+public record ExampleSection(
+        DocGenerationContext context,
+        OperationShape operation,
+        Example example
+) implements CodeSection {
+}

--- a/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/sections/ExamplesSection.java
+++ b/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/sections/ExamplesSection.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.docgen.core.sections;
+
+import java.util.List;
+import software.amazon.smithy.docgen.core.DocGenerationContext;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.traits.ExamplesTrait.Example;
+import software.amazon.smithy.utils.CodeSection;
+
+/**
+ * Generates the documentation for an operation's examples as defined by the
+ * {@code example} trait.
+ *
+ * <p>This controls all the examples for an operation. To modify a single example, use
+ * {@link ExampleSection} instead.
+ *
+ * @param context The context used to generate documentation.
+ * @param operation The operation whose examples are being documented.
+ * @param examples The list of examples that will be documented.
+ *
+ * @see ExampleSection
+ * @see software.amazon.smithy.docgen.core.generators.OperationGenerator
+ */
+public record ExamplesSection(
+        DocGenerationContext context,
+        OperationShape operation,
+        List<Example> examples
+) implements CodeSection {
+}

--- a/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/sections/ShapeSection.java
+++ b/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/sections/ShapeSection.java
@@ -6,12 +6,12 @@
 package software.amazon.smithy.docgen.core.sections;
 
 import software.amazon.smithy.docgen.core.DocGenerationContext;
-import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.utils.CodeSection;
 import software.amazon.smithy.utils.SmithyUnstableApi;
 
 /**
- * Generates documentation for non-service shapes.
+ * Generates documentation for shapes.
  *
  * @param context The context used to generate documentation.
  * @param shape   The shape whose documentation is being generated.
@@ -21,5 +21,5 @@ import software.amazon.smithy.utils.SmithyUnstableApi;
  * @see MemberSection to modify the documentation for an individual shape member.
  */
 @SmithyUnstableApi
-public record ShapeSection(DocGenerationContext context, StructureShape shape) implements CodeSection {
+public record ShapeSection(DocGenerationContext context, Shape shape) implements CodeSection {
 }

--- a/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/writers/SphinxMarkdownWriter.java
+++ b/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/writers/SphinxMarkdownWriter.java
@@ -23,6 +23,8 @@ import software.amazon.smithy.utils.SmithyUnstableApi;
 @SmithyUnstableApi
 public final class SphinxMarkdownWriter extends MarkdownWriter {
 
+    private boolean isNewTabGroup = true;
+
     /**
      * Constructs a SphinxMarkdownWriter.
      *
@@ -59,5 +61,36 @@ public final class SphinxMarkdownWriter extends MarkdownWriter {
     public DocWriter writeAnchor(String linkId) {
         write("($L)=", linkId);
         return this;
+    }
+
+    @Override
+    public DocWriter openTabGroup() {
+        isNewTabGroup = true;
+        return this;
+    }
+
+    @Override
+    public DocWriter closeTabGroup() {
+        isNewTabGroup = true;
+        return this;
+    }
+
+    @Override
+    public DocWriter openTab(String title) {
+        write(":::{tab} $L", title);
+        if (isNewTabGroup) {
+            // The inline tab plugin will automatically gather tabs into groups so long
+            // as no other elements separate them, so to make sure we never accidentally
+            // merge what should be two groups, we add this directive config to opening
+            // tabs to ensure a new group gets created.
+            write(":new-set:\n");
+            isNewTabGroup = false;
+        }
+        return this;
+    }
+
+    @Override
+    public DocWriter closeTab() {
+        return write(":::");
     }
 }

--- a/smithy-docgen-test/model/main.smithy
+++ b/smithy-docgen-test/model/main.smithy
@@ -12,8 +12,36 @@ service DocumentedService {
     operations: [
         DocumentedOperation
     ]
+    errors: [
+        ClientError
+        ServiceError
+    ]
 }
 
+@examples(
+    [
+        {
+            title: "Basic Example"
+            documentation: "This **MUST** also support CommonMark"
+            input: {
+                structure: {
+                    string: "foo"
+                    integer: 4
+                    enum: "BAR"
+                    undocumented: {boolean: false}
+                }
+            }
+            output: {
+                structure: {
+                    string: "spam"
+                    integer: 8
+                    enum: "FOO"
+                    undocumented: {boolean: true}
+                }
+            }
+        }
+    ]
+)
 operation DocumentedOperation {
     input := {
         structure: DocumentedStructure
@@ -21,6 +49,9 @@ operation DocumentedOperation {
     output := {
         structure: DocumentedStructure
     }
+    errors: [
+        DocumentedOperationError
+    ]
 }
 
 /// This structure is an example documentable structure with several members that
@@ -64,3 +95,23 @@ structure UndocumentedStructure {
     blob: Blob
     boolean: Boolean
 }
+
+@mixin
+@error("client")
+structure ErrorMixin {
+    /// The wire-level error identifier.
+    code: String
+
+    /// A message with details about why the error happened.
+    message: String
+}
+
+/// This is an error that is the fault of the calling client.
+structure ClientError with [ErrorMixin] {}
+
+/// This is an error that is the fault of the service.
+@error("server")
+structure ServiceError with [ErrorMixin] {}
+
+/// This error is only returned by DocumentedOperation
+structure DocumentedOperationError with [ErrorMixin] {}


### PR DESCRIPTION
This adds documentation generation for operation shapes.

To answer some questions that will likely come up:

> Where will HTTP / application protocol examples go?

Right alongside all the other examples, though they will always appear first in the tab listing. They are fundamentally the same things after all. Any time we might want to add some constructed snippet or example in HTTP, we should also be showing it in every other language. There's no technical reason we can't and it keeps things much more robust and consistent. The actual interface for that hasn't been created yet, however.

You can see generated docs in CI artifacts, but here's some screenshots:

![Screenshot 2023-11-02 at 16 39 22](https://github.com/smithy-lang/smithy-docgen/assets/2643092/c0f3d864-566a-4577-8af7-4bb2bd7b8a49)

And non-sphinx commonmark looks like:

![Screenshot 2023-11-02 at 16 49 13](https://github.com/smithy-lang/smithy-docgen/assets/2643092/1a4b35b2-7582-456e-8896-77837227a1b9)

(Don't get hung up on the themes)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.