### PR TITLE
Use smithy-build configuration for sphinx

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-smithyVersion=[1.39.1,2.0)
+smithyVersion=[1.41.0,2.0)
 smithyGradleVersion=0.8.0

--- a/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/integrations/SphinxIntegration.java
+++ b/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/integrations/SphinxIntegration.java
@@ -106,6 +106,11 @@ public final class SphinxIntegration implements DocIntegration {
     }
 
     @Override
+    public void configure(DocSettings settings, ObjectNode integrationSettings) {
+        this.settings = SphinxSettings.fromNode(integrationSettings);
+    }
+
+    @Override
     public List<DocFormat> docFormats(DocSettings settings) {
         return List.of(
             new DocFormat(MARKDOWN_FORMAT, ".md", new SphinxMarkdownWriter.Factory())


### PR DESCRIPTION
This updates the base smithy version to 1.41.0 to use the new ability for integrations to have their own configuration for sphinx.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.