### PR TITLE
Use definition lists for resource lifecylces

### DIFF
--- a/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/generators/MemberGenerator.java
+++ b/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/generators/MemberGenerator.java
@@ -100,19 +100,22 @@ public final class MemberGenerator implements Runnable {
                 writer.writeAnchor(linkId + "-" + listingType.getLinkIdSuffix());
             });
             writer.openHeading(listingType.getTitle());
-            writer.openMemberListing();
+            writer.openDefinitionList();
             for (MemberShape member : members) {
                 writer.pushState(new MemberSection(context, member));
 
                 var symbol = context.symbolProvider().toSymbol(member);
                 var target = context.model().expectShape(member.getTarget());
-                writer.openMemberEntry(symbol, w -> target.accept(new MemberTypeVisitor(w, context, member)));
+
+                var typeWriter = writer.consumer(w -> target.accept(new MemberTypeVisitor(w, context, member)));
+                writer.openDefinitionListItem(w -> w.writeInline("$L ($C)", symbol.getName(), typeWriter));
+
                 writer.injectSection(new ShapeSubheadingSection(context, member));
                 writer.writeShapeDocs(member, context.model());
-                writer.closeMemberEntry();
+                writer.closeDefinitionListItem();
                 writer.popState();
             }
-            writer.closeMemberListing();
+            writer.closeDefinitionList();
             writer.closeHeading();
         }
         writer.popState();
@@ -333,9 +336,9 @@ public final class MemberGenerator implements Runnable {
             if (member.hasTrait(EnumValueTrait.class)) {
                 var trait = member.expectTrait(EnumValueTrait.class);
                 if (trait.getIntValue().isPresent()) {
-                    writer.writeInline("$L", trait.expectIntValue());
+                    writer.writeInline("$`", trait.expectIntValue());
                 } else {
-                    writer.writeInline("$S", trait.expectStringValue());
+                    writer.writeInline("$`", trait.expectStringValue());
                 }
             } else {
                 writeShapeName(shape);

--- a/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/generators/ResourceGenerator.java
+++ b/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/generators/ResourceGenerator.java
@@ -19,7 +19,6 @@ import software.amazon.smithy.docgen.core.sections.ShapeDetailsSection;
 import software.amazon.smithy.docgen.core.sections.ShapeSection;
 import software.amazon.smithy.docgen.core.sections.ShapeSubheadingSection;
 import software.amazon.smithy.docgen.core.writers.DocWriter;
-import software.amazon.smithy.docgen.core.writers.DocWriter.ListType;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ResourceShape;
 import software.amazon.smithy.utils.SmithyInternalApi;
@@ -136,7 +135,7 @@ public final class ResourceGenerator implements BiConsumer<DocGenerationContext,
         var linkId = context.symbolProvider().toSymbol(resource)
                 .expectProperty(DocSymbolProvider.LINK_ID_PROPERTY, String.class);
         writer.openHeading("Lifecycle Operations", linkId + "-lifecycle-operations");
-        writer.openList(ListType.UNORDERED);
+        writer.openDefinitionList();
 
         if (resource.getPut().isPresent()) {
             var put = context.model().expectShape(resource.getPut().get(), OperationShape.class);
@@ -168,7 +167,7 @@ public final class ResourceGenerator implements BiConsumer<DocGenerationContext,
             writeLifecycleListing(context, writer, resource, list, LifecycleType.LIST);
         }
 
-        writer.closeList(ListType.UNORDERED);
+        writer.closeDefinitionList();
         writer.closeHeading();
         writer.popState();
     }
@@ -190,13 +189,15 @@ public final class ResourceGenerator implements BiConsumer<DocGenerationContext,
             LifecycleType lifecycleType
     ) {
         writer.pushState(new LifecycleOperationSection(context, resource, operation, lifecycleType));
-        writer.openListItem(ListType.UNORDERED);
+        var lifecycleName = StringUtils.capitalize(lifecycleType.name().toLowerCase(Locale.ENGLISH));
+        var operationName = context.symbolProvider().toSymbol(operation).getName();
         var reference = SymbolReference.builder()
                 .symbol(context.symbolProvider().toSymbol(operation))
-                .alias(StringUtils.capitalize(lifecycleType.name().toLowerCase(Locale.ENGLISH)))
+                .alias(String.format("%s (%s)", lifecycleName, operationName))
                 .build();
-        writer.writeInline("$R: ", reference).writeShapeDocs(operation, context.model());
-        writer.closeListItem(ListType.UNORDERED);
+        writer.openDefinitionListItem(w -> w.writeInline("$R", reference));
+        writer.writeShapeDocs(operation, context.model());
+        writer.closeDefinitionListItem();
         writer.popState();
     }
 }

--- a/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/writers/DocWriter.java
+++ b/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/writers/DocWriter.java
@@ -7,7 +7,6 @@ package software.amazon.smithy.docgen.core.writers;
 
 import java.util.function.Consumer;
 import software.amazon.smithy.codegen.core.CodegenException;
-import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolWriter;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.Shape;
@@ -192,51 +191,69 @@ public abstract class DocWriter extends SymbolWriter<DocWriter, DocImportContain
     }
 
     /**
-     * Writes any context needed before listing members.
+     * Writes any context needed to open a definition list.
      *
-     * <p>For example, a direct HTML writer might need to write out a {@code ul} tag.
+     * <p>A definition list is a list where each element has an emphasized title or
+     * term. A basic way to represent this might be an unordered list where the term
+     * is followed by a colon.
+     *
+     * <p>This will primarily be used to list members, with the element titles being
+     * the member names, member types, and a link to those member types where
+     * applicable. It will also be used for resource lifecycle operations, which will
+     * have similar titles.
      *
      * @return returns the writer.
      */
-    public abstract DocWriter openMemberListing();
+    public abstract DocWriter openDefinitionList();
 
     /**
-     * Writes any closing context needed before ending a member listing.
+     * Writes any context needed to close a definition list.
      *
-     * <p>For example, a direct HTML writer might need to write a closing {@code ul}
-     * tag.
+     * <p>A definition list is a list where each element has an emphasized title or
+     * term. A basic way to represent this might be an unordered list where the term
+     * is followed by a colon.
+     *
+     * <p>This will primarily be used to list members, with the element titles being
+     * the member names, member types, and a link to those member types where
+     * applicable. It will also be used for resource lifecycle operations, which will
+     * have similar titles.
      *
      * @return returns the writer.
      */
-    public abstract DocWriter closeMemberListing();
+    public abstract DocWriter closeDefinitionList();
 
     /**
-     * Writes out the heading information for a member's documentation.
+     * Writes any context needed to open a definition list item.
      *
-     * <p>For example, a direct HTML writer that renders member listings as HTML lists
-     * might write an opening {@code li} tag.
+     * <p>A definition list is a list where each element has an emphasized title or
+     * term. A basic way to represent this might be an unordered list where the term
+     * is followed by a colon.
      *
-     * <p>Implementations MUST create a linkable element where possible if the
-     * {@link software.amazon.smithy.docgen.core.DocSymbolProvider#LINK_ID_PROPERTY}
-     * is set.
+     * <p>This will primarily be used to list members, with the element titles being
+     * the member names, member types, and a link to those member types where
+     * applicable. It will also be used for resource lifecycle operations, which will
+     * have similar titles.
      *
-     * @param memberSymbol A symbol representing the member being documented.
-     * @param writeType A consumer that writes the type, including links to any referenced
-     *                  shapes. If the member is an enum member, it will write the literal
-     *                  value.
+     * @param titleWriter writes the title or term for the definition list item.
      * @return returns the writer.
      */
-    public abstract DocWriter openMemberEntry(Symbol memberSymbol, Consumer<DocWriter> writeType);
+    public abstract DocWriter openDefinitionListItem(Consumer<DocWriter> titleWriter);
 
     /**
-     * Writes any context needed to close out the documentation for a member.
+     * Writes any context needed to close a definition list item.
      *
-     * <p>For example, a direct HTML writer might need to write a closing {@code li}
-     * tag.
+     * <p>A definition list is a list where each element has an emphasized title or
+     * term. A basic way to represent this might be an unordered list where the term
+     * is followed by a colon.
+     *
+     * <p>This will primarily be used to list members, with the element titles being
+     * the member names, member types, and a link to those member types where
+     * applicable. It will also be used for resource lifecycle operations, which will
+     * have similar titles.
      *
      * @return returns the writer.
      */
-    public abstract DocWriter closeMemberEntry();
+    public abstract DocWriter closeDefinitionListItem();
 
     /**
      * Writes a linkable element to the documentation with the given identifier.

--- a/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/writers/MarkdownWriter.java
+++ b/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/writers/MarkdownWriter.java
@@ -14,9 +14,6 @@ import software.amazon.smithy.codegen.core.CodegenException;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolReference;
 import software.amazon.smithy.codegen.core.SymbolWriter;
-import software.amazon.smithy.docgen.core.DocSymbolProvider;
-import software.amazon.smithy.model.shapes.MemberShape;
-import software.amazon.smithy.model.traits.EnumValueTrait;
 import software.amazon.smithy.utils.Pair;
 import software.amazon.smithy.utils.SmithyUnstableApi;
 import software.amazon.smithy.utils.StringUtils;
@@ -123,33 +120,26 @@ public class MarkdownWriter extends DocWriter {
     }
 
     @Override
-    public DocWriter openMemberListing() {
+    public DocWriter openDefinitionList() {
         return this;
     }
 
     @Override
-    public DocWriter closeMemberListing() {
+    public DocWriter closeDefinitionList() {
         return this;
     }
 
     @Override
-    public DocWriter openMemberEntry(Symbol memberSymbol, Consumer<DocWriter> writeType) {
+    public DocWriter openDefinitionListItem(Consumer<DocWriter> titleWriter) {
         openListItem(ListType.UNORDERED);
-        var member = memberSymbol.expectProperty(DocSymbolProvider.SHAPE_PROPERTY, MemberShape.class);
-        if (member.hasTrait(EnumValueTrait.class)) {
-            // The type written here will be the literal for enum values. Using
-            // backticks is standard for markdown literals, and it gives some
-            // differentiation between them and normal shape members.
-            writeInline("**$L** (`$C`): ", memberSymbol.getName(), writeType);
-        } else {
-            writeInline("**$L** (*$C*): ", memberSymbol.getName(), writeType);
-        }
+        writeInline("**$C** - ", titleWriter);
         return this;
     }
 
     @Override
-    public DocWriter closeMemberEntry() {
-        return closeListItem(ListType.UNORDERED);
+    public DocWriter closeDefinitionListItem() {
+        closeListItem(ListType.UNORDERED);
+        return this;
     }
 
     @Override

--- a/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/writers/SphinxMarkdownWriter.java
+++ b/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/writers/SphinxMarkdownWriter.java
@@ -6,11 +6,7 @@
 package software.amazon.smithy.docgen.core.writers;
 
 import java.util.function.Consumer;
-import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolWriter;
-import software.amazon.smithy.docgen.core.DocSymbolProvider;
-import software.amazon.smithy.model.shapes.MemberShape;
-import software.amazon.smithy.model.traits.EnumValueTrait;
 import software.amazon.smithy.utils.SmithyUnstableApi;
 
 /**
@@ -47,26 +43,17 @@ public final class SphinxMarkdownWriter extends MarkdownWriter {
     }
 
     @Override
-    public DocWriter openMemberEntry(Symbol memberSymbol, Consumer<DocWriter> writeType) {
-        memberSymbol.getProperty(DocSymbolProvider.LINK_ID_PROPERTY, String.class).ifPresent(linkId -> {
-            write("($L)=", linkId);
-        });
-        var member = memberSymbol.expectProperty(DocSymbolProvider.SHAPE_PROPERTY, MemberShape.class);
-
-        // Writes the members as a definition list
-        if (member.hasTrait(EnumValueTrait.class)) {
-            // The type written here will be the literal for enum values. Using
-            // backticks is standard for markdown literals, and it gives some
-            // differentiation between them and normal shape members.
-            writeInline("""
-                    **$L**: `$C`
-                    :\s""", memberSymbol.getName(), writeType);
-        } else {
-            writeInline("""
-                    **$L**: $C
-                    :\s""", memberSymbol.getName(), writeType);
-        }
+    public DocWriter openDefinitionListItem(Consumer<DocWriter> titleWriter) {
+        writeInline("""
+                **$C**
+                :\s""", titleWriter);
         indent();
+        return this;
+    }
+
+    @Override
+    public DocWriter closeDefinitionListItem() {
+        dedent();
         return this;
     }
 


### PR DESCRIPTION
This updates resource lifecycle operations to use definition lists instead of normal lists. To do so, the member listing methods in DocWriter were replaced with more general definition list methods.

It also updates some feedback I received that the name of the lifecycle operations should appear on the resource page to make life easier for people writing resource policies.

<img width="1232" alt="Screenshot 2023-11-15 at 17 07 43" src="https://github.com/smithy-lang/smithy-docgen/assets/2643092/0fc858ba-4d02-4adb-bfaa-c95ae1145b52">


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.