### PR TITLE
Add noReplace note

### DIFF
--- a/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/integrations/BuiltinsIntegration.java
+++ b/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/integrations/BuiltinsIntegration.java
@@ -15,6 +15,8 @@ import software.amazon.smithy.docgen.core.interceptors.DeprecatedInterceptor;
 import software.amazon.smithy.docgen.core.interceptors.ErrorFaultInterceptor;
 import software.amazon.smithy.docgen.core.interceptors.ExternalDocsInterceptor;
 import software.amazon.smithy.docgen.core.interceptors.InternalInterceptor;
+import software.amazon.smithy.docgen.core.interceptors.NoReplaceBindingInterceptor;
+import software.amazon.smithy.docgen.core.interceptors.NoReplaceOperationInterceptor;
 import software.amazon.smithy.docgen.core.interceptors.NullabilityInterceptor;
 import software.amazon.smithy.docgen.core.interceptors.RecommendedInterceptor;
 import software.amazon.smithy.docgen.core.interceptors.SensitiveInterceptor;
@@ -61,6 +63,8 @@ public class BuiltinsIntegration implements DocIntegration {
         // the ones at the end will be at the top of the rendered pages. Therefore, interceptors
         // that provide more critical information should appear at the bottom of this list.
         return List.of(
+                new NoReplaceBindingInterceptor(),
+                new NoReplaceOperationInterceptor(),
                 new ExternalDocsInterceptor(),
                 new ErrorFaultInterceptor(),
                 new DefaultValueInterceptor(),

--- a/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/interceptors/NoReplaceBindingInterceptor.java
+++ b/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/interceptors/NoReplaceBindingInterceptor.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.docgen.core.interceptors;
+
+import software.amazon.smithy.docgen.core.DocGenerationContext;
+import software.amazon.smithy.docgen.core.sections.LifecycleOperationSection;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+/**
+ * Adds the noReplace admonition to the resource lifecycle property list on the resource page.
+ */
+@SmithyInternalApi
+public final class NoReplaceBindingInterceptor extends NoReplaceInterceptor<LifecycleOperationSection> {
+    @Override
+    public Class<LifecycleOperationSection> sectionType() {
+        return LifecycleOperationSection.class;
+    }
+
+    @Override
+    Shape getShape(LifecycleOperationSection section) {
+        return section.operation();
+    }
+
+    @Override
+    DocGenerationContext getContext(LifecycleOperationSection section) {
+        return section.context();
+    }
+}

--- a/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/interceptors/NoReplaceInterceptor.java
+++ b/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/interceptors/NoReplaceInterceptor.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.docgen.core.interceptors;
+
+import java.util.Optional;
+import software.amazon.smithy.codegen.core.SymbolReference;
+import software.amazon.smithy.docgen.core.DocGenerationContext;
+import software.amazon.smithy.docgen.core.writers.DocWriter;
+import software.amazon.smithy.docgen.core.writers.DocWriter.AdmonitionType;
+import software.amazon.smithy.model.knowledge.BottomUpIndex;
+import software.amazon.smithy.model.shapes.ResourceShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.traits.NoReplaceTrait;
+import software.amazon.smithy.utils.CodeInterceptor;
+import software.amazon.smithy.utils.CodeSection;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+/**
+ * Adds a note that a resource's put operation can't do updates if it has the
+ * <a href="https://smithy.io/2.0/spec/resource-traits.html#noreplace-trait">
+ * noReplace trait</a>.
+ */
+@SmithyInternalApi
+abstract class NoReplaceInterceptor<S extends CodeSection> implements CodeInterceptor<S, DocWriter> {
+    @Override
+    public boolean isIntercepted(S section) {
+        var shape = getShape(section);
+        var resource =  getResource(getContext(section), shape);
+        return resource.isPresent()
+                && resource.get().hasTrait(NoReplaceTrait.class)
+                && resource.get().getPut().map(put -> put.equals(shape.getId())).orElse(false);
+    }
+
+    @Override
+    public void write(
+            DocWriter writer,
+            String previousText,
+            S section
+    ) {
+        var context = getContext(section);
+        var resource = getResource(context, getShape(section)).get();
+        var resourceReference = SymbolReference.builder()
+                .alias("resource")
+                .symbol(context.symbolProvider().toSymbol(resource))
+                .build();
+        var updateSymbolReference = resource.getUpdate()
+                .map(update -> context.model().expectShape(update))
+                .map(update -> context.symbolProvider().toSymbol(update))
+                .map(symbol -> SymbolReference.builder().alias("update lifecycle operation").symbol(symbol).build());
+        writer.putContext("update", updateSymbolReference);
+        writer.writeWithNoFormatting(previousText);
+        writer.openAdmonition(AdmonitionType.NOTE);
+        writer.write("""
+                This operation cannot be used to update the $1R.\
+                ${?update} To update the $1R, use the ${update:R}.${/update}""",
+                resourceReference);
+        writer.closeAdmonition();
+    }
+
+    /**
+     * Extracts the shape for the section.
+     * @param section the section to extract the shape from.
+     * @return returns the section's shape.
+     */
+    abstract Shape getShape(S section);
+
+
+    /**
+     * Extracts the context for the section.
+     * @param section the section to extract the context from.
+     * @return returns the section's context.
+     */
+    abstract DocGenerationContext getContext(S section);
+
+    private Optional<ResourceShape> getResource(DocGenerationContext context, Shape shape) {
+        var bottomUpIndex = BottomUpIndex.of(context.model());
+        return bottomUpIndex.getResourceBinding(context.settings().service(), shape);
+    }
+
+}

--- a/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/interceptors/NoReplaceOperationInterceptor.java
+++ b/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/interceptors/NoReplaceOperationInterceptor.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.docgen.core.interceptors;
+
+import software.amazon.smithy.docgen.core.DocGenerationContext;
+import software.amazon.smithy.docgen.core.sections.ShapeDetailsSection;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+/**
+ * Adds the noReplace admonition to the resource operation's doc page.
+ */
+@SmithyInternalApi
+public final class NoReplaceOperationInterceptor extends NoReplaceInterceptor<ShapeDetailsSection> {
+    @Override
+    public Class<ShapeDetailsSection> sectionType() {
+        return ShapeDetailsSection.class;
+    }
+
+    @Override
+    Shape getShape(ShapeDetailsSection section) {
+        return section.shape();
+    }
+
+    @Override
+    DocGenerationContext getContext(ShapeDetailsSection section) {
+        return section.context();
+    }
+}

--- a/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/writers/MarkdownWriter.java
+++ b/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/writers/MarkdownWriter.java
@@ -77,7 +77,9 @@ public class MarkdownWriter extends DocWriter {
         String text;
         Optional<String> ref;
         var relativeTo = Paths.get(filename);
-        if (value instanceof Symbol symbolValue) {
+        if (value instanceof Optional<?> optional && optional.isPresent()) {
+            return getReferencePair(optional.get());
+        } else if (value instanceof Symbol symbolValue) {
             text = symbolValue.getName();
             ref = getSymbolLink(symbolValue, relativeTo);
         } else if (value instanceof SymbolReference referenceValue) {

--- a/smithy-docgen-test/model/main.smithy
+++ b/smithy-docgen-test/model/main.smithy
@@ -171,6 +171,7 @@ union DocumentedUnion {
 /// A resource shape. To have some sense of readability this will represent the concept
 /// of documentation itself as a resource, presenting the image of a service which
 /// stores such things.
+@noReplace
 resource DocumentationResource {
     identifiers: {id: DocumentationId}
     properties: {contents: DocumentationContents, archived: DocumentationArchived}


### PR DESCRIPTION
This adds a note to the put operation of resource if it has the noReplace trait indicating that it can't be used to update the resource, linking to the update operation if one is available.

This also updates the reference formatter implementation to unwrap optionals like the literal and string formatters do.

It's a tad awkward since interceptors can't intercept multiple typed sections.

<img width="1213" alt="Screenshot 2023-11-17 at 10 41 38" src="https://github.com/smithy-lang/smithy-docgen/assets/2643092/a43810a6-c2c1-48f5-be47-8e8235fdeb3b">

<img width="1213" alt="Screenshot 2023-11-17 at 10 42 36" src="https://github.com/smithy-lang/smithy-docgen/assets/2643092/eb274c52-e867-4a6a-b6a6-4d0c7bd51965">

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.