### PR TITLE
Bump minimum smithy version to 1.41.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-smithyVersion=[1.41.0,2.0)
+smithyVersion=[1.41.1,2.0)
 smithyGradleVersion=0.8.0


### PR DESCRIPTION
This bumps the minimum version of Smithy to pull in the bug fix that gives access to the reason for the recommended trait.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.