### PR TITLE
Add auth documentation

### DIFF
--- a/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/integrations/BuiltinsIntegration.java
+++ b/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/integrations/BuiltinsIntegration.java
@@ -10,6 +10,7 @@ import software.amazon.smithy.docgen.core.DocFormat;
 import software.amazon.smithy.docgen.core.DocGenerationContext;
 import software.amazon.smithy.docgen.core.DocIntegration;
 import software.amazon.smithy.docgen.core.DocSettings;
+import software.amazon.smithy.docgen.core.interceptors.ApiKeyAuthInterceptor;
 import software.amazon.smithy.docgen.core.interceptors.DefaultValueInterceptor;
 import software.amazon.smithy.docgen.core.interceptors.DeprecatedInterceptor;
 import software.amazon.smithy.docgen.core.interceptors.ErrorFaultInterceptor;
@@ -20,6 +21,7 @@ import software.amazon.smithy.docgen.core.interceptors.LengthInterceptor;
 import software.amazon.smithy.docgen.core.interceptors.NoReplaceBindingInterceptor;
 import software.amazon.smithy.docgen.core.interceptors.NoReplaceOperationInterceptor;
 import software.amazon.smithy.docgen.core.interceptors.NullabilityInterceptor;
+import software.amazon.smithy.docgen.core.interceptors.OperationAuthInterceptor;
 import software.amazon.smithy.docgen.core.interceptors.PaginationInterceptor;
 import software.amazon.smithy.docgen.core.interceptors.PatternInterceptor;
 import software.amazon.smithy.docgen.core.interceptors.RangeInterceptor;
@@ -71,6 +73,8 @@ public class BuiltinsIntegration implements DocIntegration {
         // the ones at the end will be at the top of the rendered pages. Therefore, interceptors
         // that provide more critical information should appear at the bottom of this list.
         return List.of(
+                new OperationAuthInterceptor(),
+                new ApiKeyAuthInterceptor(),
                 new PaginationInterceptor(),
                 new RequestCompressionInterceptor(),
                 new NoReplaceBindingInterceptor(),

--- a/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/interceptors/ApiKeyAuthInterceptor.java
+++ b/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/interceptors/ApiKeyAuthInterceptor.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.docgen.core.interceptors;
+
+import software.amazon.smithy.docgen.core.sections.ShapeDetailsSection;
+import software.amazon.smithy.docgen.core.writers.DocWriter;
+import software.amazon.smithy.model.traits.HttpApiKeyAuthTrait;
+import software.amazon.smithy.model.traits.HttpApiKeyAuthTrait.Location;
+import software.amazon.smithy.utils.CodeInterceptor;
+import software.amazon.smithy.utils.Pair;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+/**
+ * Adds additional context to the description of api key auth based on the customized values.
+ */
+@SmithyInternalApi
+public final class ApiKeyAuthInterceptor implements CodeInterceptor<ShapeDetailsSection, DocWriter> {
+    private static final Pair<String, String> AUTH_HEADER_REF = Pair.of(
+            "Authorization header", "https://datatracker.ietf.org/doc/html/rfc9110.html#section-11.4"
+    );
+
+    @Override
+    public Class<ShapeDetailsSection> sectionType() {
+        return ShapeDetailsSection.class;
+    }
+
+    @Override
+    public boolean isIntercepted(ShapeDetailsSection section) {
+        return section.shape().getId().equals(HttpApiKeyAuthTrait.ID);
+    }
+
+    @Override
+    public void write(DocWriter writer, String previousText, ShapeDetailsSection section) {
+        var service = section.context().model().expectShape(section.context().settings().service());
+        var trait = service.expectTrait(HttpApiKeyAuthTrait.class);
+        writer.putContext("name", trait.getName());
+        writer.putContext("location", trait.getIn().equals(Location.HEADER) ? "header" : "query string");
+        writer.putContext("scheme", trait.getScheme());
+        writer.putContext("authHeader", AUTH_HEADER_REF);
+        writer.write("""
+                The API key must be bound to the ${location:L} using the key ${name:`}.${?scheme} \
+                Additionally, the scheme used in the ${authHeader:R} must be ${scheme:`}.${/scheme}
+
+                $L""", previousText);
+    }
+}

--- a/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/interceptors/OperationAuthInterceptor.java
+++ b/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/interceptors/OperationAuthInterceptor.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.docgen.core.interceptors;
+
+import java.util.List;
+import software.amazon.smithy.docgen.core.DocgenUtils;
+import software.amazon.smithy.docgen.core.sections.ShapeDetailsSection;
+import software.amazon.smithy.docgen.core.writers.DocWriter;
+import software.amazon.smithy.docgen.core.writers.DocWriter.AdmonitionType;
+import software.amazon.smithy.model.knowledge.ServiceIndex;
+import software.amazon.smithy.model.knowledge.ServiceIndex.AuthSchemeMode;
+import software.amazon.smithy.model.shapes.ToShapeId;
+import software.amazon.smithy.model.traits.synthetic.NoAuthTrait;
+import software.amazon.smithy.utils.CodeInterceptor;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+/**
+ * Adds a priority list of supported auth schemes for operations with optional auth or
+ * operations which don't support all of a service's auth schemes.
+ */
+@SmithyInternalApi
+public final class OperationAuthInterceptor implements CodeInterceptor<ShapeDetailsSection, DocWriter> {
+    @Override
+    public Class<ShapeDetailsSection> sectionType() {
+        return ShapeDetailsSection.class;
+    }
+
+    @Override
+    public boolean isIntercepted(ShapeDetailsSection section) {
+        if (!section.shape().isOperationShape()) {
+            return false;
+        }
+        var index = ServiceIndex.of(section.context().model());
+        var service = section.context().settings().service();
+
+        // Only add the admonition if the service has auth in the first place.
+        var serviceAuth = index.getAuthSchemes(service);
+        if (serviceAuth.isEmpty()) {
+            return false;
+        }
+
+        // Only add the admonition if the operations' effective auth schemes differs
+        // from the total list of available auth schemes on the service.
+        var operationAuth = index.getEffectiveAuthSchemes(service, section.shape(), AuthSchemeMode.NO_AUTH_AWARE);
+        return !operationAuth.keySet().equals(serviceAuth.keySet());
+    }
+
+    @Override
+    public void write(DocWriter writer, String previousText, ShapeDetailsSection section) {
+        writer.writeWithNoFormatting(previousText);
+        writer.openAdmonition(AdmonitionType.IMPORTANT);
+
+        var index = ServiceIndex.of(section.context().model());
+        var service = section.context().settings().service();
+        var operation = section.shape();
+
+
+        var serviceAuth = DocgenUtils.getPrioritizedServiceAuth(section.context().model(), service);
+        var operationAuth = List.copyOf(
+                index.getEffectiveAuthSchemes(service, operation, AuthSchemeMode.MODELED).keySet());
+
+        if (serviceAuth.equals(operationAuth)) {
+            // If the total service auth and effective *modeled* operation auth are the same,
+            // that means that the operation just has optional auth since isIntercepted would
+            // return false otherwise. It would have been overly confusing to include this
+            // case in the big text block below.
+            writer.write("""
+                    This operation may be optionally called without authentication.
+                    """);
+            writer.closeAdmonition();
+            return;
+        }
+
+        var operationSchemes = operationAuth.stream()
+                .map(id -> section.context().symbolProvider().toSymbol(section.context().model().expectShape(id)))
+                .toList();
+
+        writer.putContext("optional", supportsNoAuth(index, service, section.shape()));
+        writer.putContext("schemes", operationSchemes);
+        writer.putContext("multipleSchemes", operationSchemes.size() > 1);
+
+        writer.write("""
+                ${?schemes}This operation ${?optional}may optionally${/optional}${^optional}MUST${/optional} \
+                be called with ${?multipleSchemes}one of the following priority-ordered auth schemes${/multipleSchemes}\
+                ${^multipleSchemes}the following auth scheme${/multipleSchemes}: \
+                ${#schemes}${value:R}${^key.last}, ${/key.last}${/schemes}.${/schemes}\
+                ${^schemes}${?optional}This operation must be called without authentication.${/optional}${/schemes}
+                """);
+        writer.closeAdmonition();
+    }
+
+    private boolean supportsNoAuth(ServiceIndex index, ToShapeId service, ToShapeId operation) {
+        return index.getEffectiveAuthSchemes(service, operation, AuthSchemeMode.NO_AUTH_AWARE)
+                .containsKey(NoAuthTrait.ID);
+    }
+}

--- a/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/sections/AuthSection.java
+++ b/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/sections/AuthSection.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.docgen.core.sections;
+
+import software.amazon.smithy.docgen.core.DocGenerationContext;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.utils.CodeSection;
+import software.amazon.smithy.utils.SmithyUnstableApi;
+
+/**
+ * Contains the documentation for the auth schemes that the service supports.
+ *
+ * <p>By default, the auth schemes are documented in a definition list. The title
+ * used for each auth scheme is the name that results from passing the auth trait's
+ * shape to the {@link software.amazon.smithy.docgen.core.DocSymbolProvider}. The
+ * name can be customized by decorating the provider with
+ * {@link software.amazon.smithy.docgen.core.DocIntegration#decorateSymbolProvider}.
+ *
+ * <p>The body of each auth scheme's docs is treated like a typical shape section,
+ * with a {@link ShapeSection}, {@link ShapeSubheadingSection},
+ * {@link ShapeDetailsSection}, and documentation pulled from the shape. Details
+ * based on the trait's values can be inserted via one of those sections, intercepting
+ * when the shape's id matches the id of the auth trait's shape.
+ *
+ * @param context The context used to generate documentation.
+ * @param service The service whose documentation is being generated.
+ *
+ * @see ShapeSection to override documentation for individual auth schemes.
+ * @see software.amazon.smithy.docgen.core.interceptors.ApiKeyAuthInterceptor for an
+ *     example of adding details to an auth trait's docs based on its values.
+ */
+@SmithyUnstableApi
+public record AuthSection(DocGenerationContext context, ServiceShape service) implements CodeSection {
+}

--- a/smithy-docgen-test/model/main.smithy
+++ b/smithy-docgen-test/model/main.smithy
@@ -7,10 +7,19 @@ namespace com.example
 /// should handle. For example, the implementation <b>must</b> be able to handle HTML
 /// tags since that's part of the [CommonMark spec](https://spec.commonmark.org/).
 @title("Documented Service")
+@httpBasicAuth
+@httpDigestAuth
+@httpBearerAuth
+@httpApiKeyAuth(name: "auth-bearing-header", in: "header", scheme: "Bearer")
+@auth([httpApiKeyAuth, httpBearerAuth, httpDigestAuth])
 service DocumentedService {
     version: "2023-10-13"
     operations: [
         DocumentedOperation
+        UnauthenticatedOperation
+        OptionalAuthOperation
+        LimitedAuthOperation
+        LimitedOptionalAuthOperation
     ]
     resources: [
         DocumentationResource
@@ -20,6 +29,23 @@ service DocumentedService {
         ServiceError
     ]
 }
+
+/// This operation does not support any of the service's auth types.
+@auth([])
+operation UnauthenticatedOperation {}
+
+/// This operation supports all of the service's auth types, but optionally.
+@optionalAuth
+operation OptionalAuthOperation {}
+
+/// This operation supports a limited set of the service's auth.
+@auth([httpBasicAuth, httpApiKeyAuth])
+operation LimitedAuthOperation {}
+
+/// This operation supports a limited set of the service's auth, optionally.
+@optionalAuth
+@auth([httpBasicAuth, httpDigestAuth])
+operation LimitedOptionalAuthOperation {}
 
 @examples(
     [


### PR DESCRIPTION
This adds a documentation section to the service's page covering the available auth types and a notice to each operation's page if it has optional auth, fewer auth types, and/or a different auth type.

See also: https://github.com/smithy-lang/smithy/pull/2051

<img width="1226" alt="Screenshot 2023-11-24 at 12 35 14" src="https://github.com/smithy-lang/smithy-docgen/assets/2643092/af5d1b52-aa0d-47d0-96f1-9aff850e6eba">


<img width="1226" alt="Screenshot 2023-11-24 at 12 34 44" src="https://github.com/smithy-lang/smithy-docgen/assets/2643092/645c40e5-ba8e-4d0c-8b2c-fff020b7f8f5">



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.