### PR TITLE
Update sample package

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ which have default support.
 * [references](https://smithy.io/2.0/spec/resource-traits.html#smithy-api-references-trait)
 * [requestCompression](https://smithy.io/2.0/spec/behavior-traits.html#smithy-api-requestcompression-trait)
 * [retryable](https://smithy.io/2.0/spec/behavior-traits.html#smithy-api-retryable-trait)
+* [endpoint](https://smithy.io/2.0/spec/endpoint-traits.html)
 
 ## Security
 

--- a/smithy-docgen-test/model/main.smithy
+++ b/smithy-docgen-test/model/main.smithy
@@ -11,10 +11,27 @@ use aws.protocols#awsJson1_0
 use aws.protocols#restJson1
 use aws.protocols#restXml
 
-/// This service is not intended to be representative of a real service. Rather, it is
-/// meant to exercise different kinds of behavior that the documentation generator
-/// should handle. For example, the implementation <b>must</b> be able to handle HTML
-/// tags since that's part of the [CommonMark spec](https://spec.commonmark.org/).
+/// This is a sample service meant to exercise and demonstrate different kinds
+/// of behavior that the documentation generator should handle. Click around to
+/// different pages to see what it can do. Examples for various traits are
+/// put into sections matching their sections in the Smithy docs.
+///
+/// This service uses many different auth and protocol traits to demonstrate
+/// how that will look, though in practice most services will only use one
+/// or two of each. One important thing to note is the ordering of the
+/// documented auth traits. By default it uses the same ordering as the
+/// [auth trait](https://smithy.io/2.0/spec/authentication-traits.html#auth-trait)
+/// if present. Anything not in that list is added to the end. On this service,
+/// the only auth trait not present in the list is `httpBasicAuth`.
+///
+/// For the most part, this doesn't go to any effort to pretend to be a real
+/// service, operations and paramters will be named according to what they're
+/// demonstrating rather than according to some kind of theme.
+///
+/// One feature the implementation <b>must</b> support, for example, is the
+/// ability to handle HTML tags in the documentation trait. This is because the
+/// documentation trait uses the [CommonMark](https://spec.commonmark.org/)
+/// format, which supports inline HTML.
 @title("Documented Service")
 @httpBasicAuth
 @httpDigestAuth
@@ -27,12 +44,20 @@ use aws.protocols#restXml
 service DocumentedService {
     version: "2023-10-13"
     operations: [
-        DocumentedOperation
-        UnauthenticatedOperation
-        OptionalAuthOperation
-        LimitedAuthOperation
-        LimitedOptionalAuthOperation
+        ConstraintTraits
+        TypeRefinementTraits
+        DocumentationTraits
+        BehaviorTraits
+        DefaultAuth
+        Unauthenticated
+        OptionalAuth
+        LimitedAuth
+        LimitedOptionalAuth
+        ProtocolTraits
+        StreamingTraits
         HttpTraits
+        EndpointTraits
+        Misc
     ]
     resources: [
         DocumentationResource
@@ -43,177 +68,373 @@ service DocumentedService {
     ]
 }
 
-/// This operation showcases most of the various HTTP traits.
-@http(method: "POST", uri: "/HttpTraits/{label}/{greedyLabel+}?static", code: 200)
-@httpChecksumRequired
-operation HttpTraits {
+/// This operation showcases most of the various
+/// [constraint traits](https://smithy.io/2.0/spec/constraint-traits.html).
+///
+/// Note that the `idref` trait isn't supported since it's only used for traits
+/// and doesn't reflect the API. The `private` trait similarly doesn't have
+/// any impact on the API.
+@http(method: "POST", uri: "/ConstraintTraits")
+operation ConstraintTraits with [AllAuth] {
     input := {
-        /// This is a label member that's bound to a normal label.
-        @httpLabel
-        @required
-        label: String
+        lengthExamples: LengthTraitExamples
 
-        /// This is a label member that's bound to a greedy label.
-        @httpLabel
-        @required
-        greedyLabel: String
+        /// This member has a pattern trait on it.
+        @pattern("^[A-Za-z]+$")
+        pattern: String
 
-        /// This is a header member bound to a single static header.
-        @httpHeader("x-custom-header")
-        singletonHeader: String
+        rangeExamples: RangeTraitExamples
 
-        /// This is a header member that's bound to a list.
-        @httpHeader("x-list-header")
-        listHeader: StringList
+        uniqueItems: StringSet
 
-        /// This is a header member that's bound to a map with a prefix.
-        @httpPrefixHeaders("prefix-")
-        prefixHeaders: DenseStringMap
+        enum: StringEnum
 
-        /// This is a query param that's bound to a single param.
-        @httpQuery("singelton")
-        singletonQuery: String
-
-        /// This is a query param that's bound to a list.
-        @httpQuery("list")
-        listQuery: StringList
-
-        /// This is an open listing of all query params.
-        @httpQueryParams
-        mapQuery: StringMap
-
-        /// This is the operation's payload, only useable since everything
-        /// else is bound to some other part of the HTTP request.
-        @httpPayload
-        payload: Blob
-    }
-
-    output := {
-        /// This allows people to more easily interact with the http response
-        /// without having to leak the response object.
-        @httpResponseCode
-        responseCode: Integer
+        intEnum: IntEnum
     }
 }
 
-/// This operation does not support any of the service's auth types.
-@auth([])
-@http(method: "POST", uri: "/UnauthenticatedOperation")
-operation UnauthenticatedOperation {}
+/// This shows how the length trait is applied to various types.
+structure LengthTraitExamples {
+    @length(min: 4)
+    string: String
 
-/// This operation supports all of the service's auth types, but optionally.
-@optionalAuth
-@http(method: "POST", uri: "/OptionalAuthOperation")
-operation OptionalAuthOperation {}
+    @length(max: 255)
+    blob: Blob
 
-/// This operation supports a limited set of the service's auth.
-@auth([httpBasicAuth, httpApiKeyAuth])
-@http(method: "POST", uri: "/LimitedAuthOperation")
-operation LimitedAuthOperation {}
+    @length(min: 2, max: 4)
+    list: StringSet
 
-/// This operation supports a limited set of the service's auth, optionally.
-@optionalAuth
-@auth([httpBasicAuth, httpDigestAuth])
-@http(method: "POST", uri: "/LimitedOptionalAuthOperation")
-operation LimitedOptionalAuthOperation {}
+    map: StringMap
+}
 
+/// A set of strings, using the
+/// [uniqueItems](https://smithy.io/2.0/spec/constraint-traits.html#uniqueitems-trait)
+/// trait to make the list effectively and ordered set.
+@uniqueItems
+list StringSet {
+    member: String
+}
+
+/// A string map that allows null values.
+@length(max: 16)
+map StringMap {
+    key: String
+    value: String
+}
+
+/// This shows how the range trait is applied to various types.
+structure RangeTraitExamples {
+    @range(min: 0)
+    positive: Integer
+
+    @range(max: 0)
+    negative: Long
+
+    @range(min: 0, max: 255)
+    unsignedByte: Short
+}
+
+/// This in an enum that can have one of the following values:
+///
+/// - `FOO`
+/// - `BAR`
+///
+/// Like other shapes in the model, this doesn't actually mean anything.
+enum StringEnum {
+    /// One of the more common placeholders in the programming world.
+    FOO
+
+    /// Another very common placeholder, often seen with `foo`.
+    BAR
+}
+
+/// This in an enum that can have one of the following values:
+///
+/// - `SPAM`: `1`
+/// - `EGGS`: `2`
+///
+/// Like other shapes in the model, this doesn't actually mean anything.
+intEnum IntEnum {
+    /// The spam and eggs placeholders are really only common in Python code bases.
+    SPAM = 1
+
+    /// They're a reference to a famous Monty Python skit, which is fitting because the
+    /// language itself is named after Monty Python.
+    EGGS = 2
+}
+
+/// This operation showcases the various
+/// [type refinement traits](https://smithy.io/2.0/spec/type-refinement-traits.html).
+///
+/// Note that `input` and `output` traits have the effect of moving the shape's
+/// docs into the operation page with no dedicated shape page since it can't be
+/// otherwise referenced.
+///
+/// The `mixin` trait has no effect on the API, so it's not documented. The generator
+/// will skip generating anything for them.
+@http(method: "POST", uri: "/TypeRefinementTraits")
+operation TypeRefinementTraits with [AllAuth] {
+    input := {
+        /// A boolean with a default value.
+        defaultBoolean: Boolean = true
+
+        /// An enum with a default value.
+        defaultEnum: StringEnum = "FOO"
+
+        /// An integer with a default that was addded after initial publication
+        /// and was annotated with the
+        /// [addedDefault trait](https://smithy.io/2.0/spec/type-refinement-traits.html#addeddefault-trait).
+        /// Currently that trait doesn't impact the docs.
+        @addedDefault
+        addedDefault: Integer = 5
+
+        /// A member that's required. Note that many of the resource operations
+        /// and http bindings will also have required traits since they need
+        /// them.
+        @required
+        required: String
+
+        /// This member is optional for clients. Since this is API
+        /// documentation, that's not reflected here.
+        @clientOptional
+        @required
+        clientOptional: String
+
+        enumValue: NonMatchingEnum
+    }
+
+    output := {
+        sparseList: SparseList
+        sparseMap: SparseMap
+    }
+
+    errors: [
+        SimpleError
+    ]
+}
+
+/// This string enum has values that don't match the member names.
+enum NonMatchingEnum {
+    /// Note that the actual wire value is lower-case.
+    FOO = "foo"
+
+    /// Note that the actual wire value is completely different.
+    BAR = "example"
+}
+
+/// A list that allows null values.
+@sparse
+list SparseList {
+    member: String
+}
+
+/// A map that allows null values.
+@sparse
+map SparseMap {
+    key: String
+    value: String
+}
+
+/// This error is as basic as the protocols allow.
+structure SimpleError with [ErrorMixin] {}
+
+/// This operation showcases the various
+/// [documentation traits](https://smithy.io/2.0/spec/documentation-traits.html).
+///
+/// Note that examples are only half-supported right now. An interface needs
+/// to be created and implemented to allow both code generators and protocols
+/// to provide examples that will be used in those sections. For now, it just
+/// shows the raw input / output structures.
+///
+/// The `title` trait is applied to the service.
 @examples(
     [
         {
             title: "Basic Example"
-            documentation: "This **MUST** also support CommonMark"
             input: {
-                structure: {
-                    string: "foo"
-                    integer: 4
-                    enum: "BAR"
-                    undocumented: {boolean: false}
-                }
+                deprecated: {deprecatedSince: "foo"}
             }
-            output: {
-                structure: {
-                    string: "spam"
-                    integer: 8
-                    enum: "FOO"
-                    undocumented: {boolean: true}
-                }
+            output: {}
+        }
+        {
+            title: "Error example"
+            documentation: "This shows an error response example."
+            input: {
+                deprecated: {deprecatedMessage: "bar"}
+            }
+            error: {
+                shapeId: SimpleError
+                content: {message: "That's super deprecated, don't use it."}
             }
         }
     ]
 )
-@requestCompression(
-    encodings: ["gzip"]
-)
-@http(method: "POST", uri: "/DocumentedOperation")
-operation DocumentedOperation {
+@http(method: "POST", uri: "/DocumentationTraits")
+operation DocumentationTraits with [AllAuth] {
     input := {
-        /// This is an idempotency token, which will inherently mark this operation
-        /// as idempotent.
-        @idempotencyToken
-        token: String
+        noDocumentationTrait: Long
 
-        structure: DocumentedStructure
+        deprecated: DeprecatedExamples
 
-        lengthExamples: LengthTraitExamples
+        /// While you can link things directly inside of the doc trait, you
+        /// can also used the external docs trait to provide see-also type
+        /// links.
+        @externalDocumentation("trait docs": "https://smithy.io/2.0/spec/documentation-traits.html#externaldocumentation-trait")
+        externalDocumentation: String
 
-        rangeExamples: RangeTraitExamples
+        /// This is distinct from required.
+        @recommended
+        recommended: String
+
+        /// This has its own custom reason for why it's recommended.
+        @recommended(reason: "Because you can.")
+        reasonablyRecommended: String
+
+        /// Sensitive data could be anything, but it shouldn't be logged.
+        sensitive: SensitiveBlob
+
+        /// This indicates when it was added.
+        @since("2020-03-01")
+        since: Integer
+
+        /// This has a number of tags, though said tags aren't part of the docs
+        /// and likely won't be. They're mostly useful for organizing the model
+        /// itself.
+        @tags(["foo", "bar"])
+        tags: Short
     }
 
     output := {
-        structure: DocumentedStructure
+        /// This integer being unstable could mean later it becomes an enum, or
+        /// a different number type, or evern be removed.
+        @unstable
+        unstable: Integer
     }
 
     errors: [
-        DocumentedOperationError
+        SimpleError
     ]
 }
 
-/// This structure is an example documentable structure with several members that
-/// also must be documented. This is intended as a base case with standard members
-/// that don't do anything crazy. More complex use cases should be put in their own
-/// structure to ensure this model is easy to traverse.
-@externalDocumentation(
-    "Smithy Reference": "https://smithy.io/"
-    Structures: "https://smithy.io/2.0/spec/aggregate-types.html#structure"
-)
-structure DocumentedStructure {
-    /// This is a simple string member.
-    /// It has documentation that can span multiple lines.
-    @since("2023-11-16")
-    @jsonName("foo")
-    @xmlName("bar")
-    string: String
-
-    /// This member has a pattern trait on it.
-    @pattern("^[A-Za-z]+$")
-    pattern: String
-
-    /// This is a simple integer member.
+/// This showcases the different ways a shape can be marked as deprecated.
+@deprecated
+structure DeprecatedExamples {
     @deprecated
-    integer: Integer
+    deprecated: String
 
-    /// This is a timestamp with a custom format
-    timestamp: DateTime
+    @deprecated(since: "2020-03-01")
+    deprecatedSince: String
 
-    // This doesn't have a doc string (this is just a normal comment), so it should
-    // pull the docs from the target shape.
-    @deprecated(message: "Please use intEnum instead")
-    enum: DocumentedStringEnum
+    @deprecated(message: "This gets a custom  message.")
+    deprecatedMessage: String
 
-    // This also will pull docs from the shape.
-    intEnum: DocumentedIntEnum
-
-    @deprecated(since: "2023-11-15")
-    undocumented: UndocumentedStructure
-
-    /// This is a self-referential member. This is a thing that should be possible.
-    self: DocumentedStructure
-
-    @recommended(reason: "Because unions are cool")
-    union: DocumentedUnion
-
-    xmlTraits: XmlTraits
+    @deprecated(since: "2020-03-01", message: "This gets a custom message too.")
+    fullDeprecated: String
 }
+
+@sensitive
+blob SensitiveBlob
+
+/// This operation showcases the various
+/// [behavior traits](https://smithy.io/2.0/spec/behavior-traits.html).
+///
+/// See the various read operations in the resource examples for an
+/// example of the `readonly` trait. Similarly, see the list operations for
+/// examples of pagination.
+@requestCompression(
+    encodings: ["gzip"]
+)
+@idempotent
+@http(method: "POST", uri: "/BehaviorTraits")
+operation BehaviorTraits with [AllAuth] {
+    input := {
+        /// This token is still required for services.
+        @idempotencyToken
+        idempotencyToken: String
+    }
+
+    errors: [
+        RetryableError
+    ]
+}
+
+/// An error that's explicitly retryable.
+@retryable
+@error("server")
+@httpError(500)
+structure RetryableError with [ErrorMixin] {}
+
+// This mixin provides all of the auth types available to the service, in the
+// default expected priority. In effect, this hides the auth annotations that
+// will otherwise appear since the service does not list all of its auth types
+// in its auth trait list.
+@mixin
+@auth([httpApiKeyAuth, httpBearerAuth, httpDigestAuth, httpBasicAuth])
+operation AllAuth {}
+
+/// This operation uses the service's default auth list. Since that doesn't
+/// include all of the possible auth types, this should display information
+/// indicating what this operation supports.
+///
+/// You may wonder why it's like this, and why the auth information doesn't
+/// just show up when the operation's list differs from what is on the
+/// service's auth list. The answer is that auth documenation is inherently
+/// a top level affair, so all of the possible auth needs to be documented at
+/// the top level. So when an operation doesn't support all the possible auth
+/// types, that has to be called out.
+@http(method: "POST", uri: "/DefaultAuth")
+operation DefaultAuth {}
+
+/// This operation does not support any of the service's auth types.
+@auth([])
+@http(method: "POST", uri: "/Unauthenticated")
+operation Unauthenticated {}
+
+/// This operation supports all of the service's auth types, but optionally.
+@optionalAuth
+@http(method: "POST", uri: "/OptionalAuth")
+operation OptionalAuth with [AllAuth] {}
+
+/// This operation supports a limited set of the service's auth.
+@auth([httpBasicAuth, httpApiKeyAuth])
+@http(method: "POST", uri: "/LimitedAuth")
+operation LimitedAuth {}
+
+/// This operation supports a limited set of the service's auth, optionally.
+@optionalAuth
+@auth([httpBasicAuth, httpDigestAuth])
+@http(method: "POST", uri: "/LimitedOptionalAuth")
+operation LimitedOptionalAuth {}
+
+/// This operation showcases the various
+/// [serialization and protocol traits](https://smithy.io/2.0/spec/behavior-traits.html).
+@http(method: "POST", uri: "/ProtocolTraits")
+operation ProtocolTraits with [AllAuth] {
+    input := {
+        /// This has a name representation in JSON that differs from the member name.
+        @jsonName("spam")
+        jsonName: String
+
+        /// This targets a shape with a media type. This trait is currently unuspported.
+        mediaType: VideoData
+
+        /// This is a timestamp with a custom format.
+        timestamp: DateTime
+
+        /// This is a timestamp without a custom format.
+        plainTimestamp: Timestamp
+
+        xmlTraits: XmlTraits
+
+        /// This member has different traits for the different protocols.
+        @jsonName("foo")
+        @xmlName("bar")
+        differentProtocols: String
+    }
+}
+
+@mediaType("video/quicktime")
+blob VideoData
 
 /// Timestamp in RFC3339 format
 @timestampFormat("date-time")
@@ -256,92 +477,109 @@ list StringList {
     member: String
 }
 
-/// This in an enum that can have one of the following values:
-///
-/// - `FOO`
-/// - `BAR`
-///
-/// Like other shapes in the model, this doesn't actually mean anything.
-enum DocumentedStringEnum {
-    /// One of the more common placeholders in the programming world.
-    FOO
-
-    /// Another very common placeholder, often seen with `foo`.
-    BAR
+/// This showcases the `streaming` trait with a data stream.
+@http(method: "POST", uri: "/StreamingTraits")
+operation StreamingTraits with [AllAuth] {
+    input := {
+        @httpPayload
+        output: StreamingBlob = ""
+    }
 }
 
-/// This shows how the length trait is applied to various types.
-structure LengthTraitExamples {
-    @length(min: 4)
+/// This is a streaming blob. The streaming trait is not currently
+/// supported either for data streams or event streams.
+@streaming
+@requiresLength
+blob StreamingBlob
+
+// TODO: add event stream traits
+/// This operation showcases most of the various
+/// [HTTP traits](https://smithy.io/2.0/spec/http-bindings.html).
+@http(method: "POST", uri: "/HttpTraits/{label}/{greedyLabel+}?static", code: 200)
+@httpChecksumRequired
+operation HttpTraits with [AllAuth] {
+    input := {
+        /// This is a label member that's bound to a normal label.
+        @httpLabel
+        @required
+        label: String
+
+        /// This is a label member that's bound to a greedy label.
+        @httpLabel
+        @required
+        greedyLabel: String
+
+        /// This is a header member bound to a single static header.
+        @httpHeader("x-custom-header")
+        singletonHeader: String
+
+        /// This is a header member that's bound to a list.
+        @httpHeader("x-list-header")
+        listHeader: StringList
+
+        /// This is a header member that's bound to a map with a prefix.
+        @httpPrefixHeaders("prefix-")
+        prefixHeaders: StringMap
+
+        /// This is a query param that's bound to a single param.
+        @httpQuery("singelton")
+        singletonQuery: String
+
+        /// This is a query param that's bound to a list.
+        @httpQuery("list")
+        listQuery: StringList
+
+        /// This is an open listing of all query params.
+        @httpQueryParams
+        mapQuery: StringMap
+
+        /// This is the operation's payload, only useable since everything
+        /// else is bound to some other part of the HTTP request.
+        @httpPayload
+        payload: Blob
+    }
+
+    output := {
+        /// This allows people to more easily interact with the http response
+        /// without having to leak the response object.
+        @httpResponseCode
+        responseCode: Integer
+    }
+}
+
+/// The endpoint traits are currently not supported.
+@endpoint(hostPrefix: "{foo}.data.")
+@http(method: "POST", uri: "/EndpointTraits")
+operation EndpointTraits with [AllAuth] {
+    input := {
+        /// This will be sent both as part of the endpoint prefix and in the
+        /// message body.
+        @required
+        @hostLabel
+        foo: String
+    }
+}
+
+/// This operation showcases anything that doesn't fit cleanly into one of the
+/// other showcase operations.
+@http(method: "POST", uri: "/Misc")
+operation Misc with [AllAuth] {
+    input := {
+        union: DocumentedUnion
+    }
+}
+
+/// Unions can only have one member set. The member name is used as a tag to
+/// determine which member is intended at runtime.
+union DocumentedUnion {
+    /// Union members for the most part look like structure members, with the exception
+    /// that exactly one must be set.
     string: String
 
-    @length(max: 255)
-    blob: Blob
-
-    @length(min: 2, max: 4)
-    list: StringSet
-
-    map: StringMap
+    /// It doesn't matter that multiple members target the same type, since the type
+    /// isn't the discriminator, the tag (member name) is.
+    otherString: String
 }
-
-/// A set of strings.
-@uniqueItems
-list StringSet {
-    member: String
-}
-
-/// A string map that allows null values.
-@sparse
-@length(max: 16)
-map StringMap {
-    key: String
-    value: String
-}
-
-/// A map that disallows null values.
-map DenseStringMap {
-    key: String
-    value: String
-}
-
-/// This shows how the range trait is applied to various types.
-structure RangeTraitExamples {
-    @range(min: 0)
-    positive: Integer
-
-    @range(max: 0)
-    negative: Long
-
-    @range(min: 0, max: 255)
-    unsignedByte: Short
-}
-
-/// This in an enum that can have one of the following values:
-///
-/// - `SPAM`: `1`
-/// - `EGGS`: `2`
-///
-/// Like other shapes in the model, this doesn't actually mean anything.
-intEnum DocumentedIntEnum {
-    /// The spam and eggs placeholders are really only common in Python code bases.
-    SPAM = 1
-
-    /// They're a reference to a famous Monty Python skit, which is fitting because the
-    /// language itself is named after Monty Python.
-    EGGS = 2
-}
-
-// This structure has no docs anywhere
-@unstable
-structure UndocumentedStructure {
-    blob: SensitiveBlob
-
-    @internal
-    boolean: Boolean
-}
-
-@sensitive
-blob SensitiveBlob
 
 @mixin
 @error("client")
@@ -362,23 +600,6 @@ structure ClientError with [ErrorMixin] {}
 @httpError(500)
 structure ServiceError with [ErrorMixin] {}
 
-/// This error is only returned by DocumentedOperation
-structure DocumentedOperationError with [ErrorMixin] {}
-
-/// Unions can only have one member set. The member name is used as a tag to
-/// determine which member is intended at runtime.
-union DocumentedUnion {
-    /// Union members for the most part look like structure members, with the exception
-    /// that exactly one must be set.
-    string: String
-
-    /// It doesn't matter that multiple members target the same type, since the type
-    /// isn't the discriminator, the tag (member name) is.
-    otherString: String
-
-    struct: DocumentedStructure
-}
-
 /// A resource shape. To have some sense of readability this will represent the concept
 /// of documentation itself as a resource, presenting the image of a service which
 /// stores such things.
@@ -386,17 +607,17 @@ union DocumentedUnion {
 resource DocumentationResource {
     identifiers: {id: DocumentationId}
     properties: {contents: DocumentationContents, archived: DocumentationArchived}
-    put: PutDocumentation
-    create: CreateDocumentation
-    read: GetDocumentation
-    update: UpdateDocumentation
-    delete: DeleteDocumentation
-    list: ListDocumentation
+    put: PutDocs
+    create: CreateDocs
+    read: GetDocs
+    update: UpdateDocs
+    delete: DeleteDocs
+    list: ListDocs
     operations: [
-        ArchiveDocumentation
+        ArchiveDocs
     ]
     collectionOperations: [
-        DeleteArchivedDocumentation
+        DeleteArchivedDocs
     ]
     resources: [
         DocumentationArtifact
@@ -420,7 +641,7 @@ boolean DocumentationArchived
 /// Put operations create a resource with a user-specified identifier.
 @idempotent
 @http(method: "PUT", uri: "/DocumentationResource/{id}")
-operation PutDocumentation {
+operation PutDocs with [AllAuth] {
     input := for DocumentationResource {
         @required
         @httpLabel
@@ -433,7 +654,7 @@ operation PutDocumentation {
 
 /// Create operations instead have the service create the identifier.
 @http(method: "POST", uri: "/DocumentationResource")
-operation CreateDocumentation {
+operation CreateDocs with [AllAuth] {
     input := for DocumentationResource {
         @required
         $contents
@@ -443,7 +664,7 @@ operation CreateDocumentation {
 /// Gets the contents of a documentation resource.
 @readonly
 @http(method: "GET", uri: "/DocumentationResource/{id}")
-operation GetDocumentation {
+operation GetDocs with [AllAuth] {
     input := for DocumentationResource {
         @required
         @httpLabel
@@ -466,7 +687,7 @@ operation GetDocumentation {
 /// lifecycle operation.
 @idempotent
 @http(method: "PUT", uri: "/DocumentationResource")
-operation UpdateDocumentation {
+operation UpdateDocs with [AllAuth] {
     input := for DocumentationResource {
         @required
         @httpQuery("id")
@@ -480,7 +701,7 @@ operation UpdateDocumentation {
 /// Deletes documentation.
 @idempotent
 @http(method: "DELETE", uri: "/DocumentationResource/{id}")
-operation DeleteDocumentation {
+operation DeleteDocs with [AllAuth] {
     input := for DocumentationResource {
         @required
         @httpLabel
@@ -493,7 +714,7 @@ operation DeleteDocumentation {
 /// operations to make sure both cases are being documented.
 @idempotent
 @http(method: "PUT", uri: "/DocumentationResource/{id}/archive")
-operation ArchiveDocumentation {
+operation ArchiveDocs with [AllAuth] {
     input := for DocumentationResource {
         @required
         @httpLabel
@@ -506,13 +727,13 @@ operation ArchiveDocumentation {
 /// is being documented as expected.
 @http(method: "DELETE", uri: "/DocumentationResource?delete-archived")
 @idempotent
-operation DeleteArchivedDocumentation {}
+operation DeleteArchivedDocs with [AllAuth] {}
 
 /// Lists the avialable documentation resources.
 @readonly
 @http(method: "GET", uri: "/DocumentationResource")
 @paginated(inputToken: "paginationToken", outputToken: "paginationToken", items: "documentation", pageSize: "pageSize")
-operation ListDocumentation {
+operation ListDocs with [AllAuth] {
     input := {
         /// Whether to list documentation that has been archived.
         @httpQuery("showArchived")
@@ -553,9 +774,9 @@ structure Documentation for DocumentationResource {
 resource DocumentationArtifact {
     identifiers: {id: DocumentationId, artifactId: DocumentationArtifactId}
     properties: {data: DocumentationArtifactData}
-    put: PutDocumentationArtifact
-    read: GetDocumentationArtifact
-    delete: DeleteDocumentationArtifact
+    put: PutDocArtifact
+    read: GetDocArtifact
+    delete: DeleteDocArtifact
 }
 
 /// Sub-resources need distinct identifiers.
@@ -566,7 +787,7 @@ blob DocumentationArtifactData
 
 @idempotent
 @http(method: "PUT", uri: "/DocumentationResource/{id}/artifact/{artifactId}")
-operation PutDocumentationArtifact {
+operation PutDocArtifact with [AllAuth] {
     input := for DocumentationArtifact {
         @required
         @httpLabel
@@ -583,7 +804,7 @@ operation PutDocumentationArtifact {
 
 @readonly
 @http(method: "GET", uri: "/DocumentationResource/{id}/artifact/{artifactId}")
-operation GetDocumentationArtifact {
+operation GetDocArtifact with [AllAuth] {
     input := for DocumentationArtifact {
         @required
         @httpLabel
@@ -608,7 +829,7 @@ operation GetDocumentationArtifact {
 
 @idempotent
 @http(method: "DELETE", uri: "/DocumentationResource/{id}/artifact/{artifactId}")
-operation DeleteDocumentationArtifact {
+operation DeleteDocArtifact with [AllAuth] {
     input := for DocumentationArtifact {
         @required
         @httpLabel


### PR DESCRIPTION
This updates the sample docs package to be better organized. The new structure mostly follows how Smithy organizes traits into pages. No screenshots because everything is changed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.