### PR TITLE
Use badges for recommended and required

### DIFF
--- a/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/integrations/SphinxIntegration.java
+++ b/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/integrations/SphinxIntegration.java
@@ -97,7 +97,8 @@ public final class SphinxIntegration implements DocIntegration {
             "Sphinx==7.2.6",
             "sphinx_inline_tabs==2023.4.21",
             "sphinx-copybutton==0.5.2",
-            "Pygments==2.16.1"
+            "Pygments==2.16.1",
+            "sphinx-design==0.5.0"
     );
     private static final List<String> FURO_REQUIREMENTS = List.of("furo==2023.9.10");
     private static final List<String> MARKDOWN_REQUIREMENTS = List.of(
@@ -107,7 +108,8 @@ public final class SphinxIntegration implements DocIntegration {
 
     private static final List<String> BASE_EXTENSIONS = List.of(
             "sphinx_inline_tabs",
-            "sphinx_copybutton"
+            "sphinx_copybutton",
+            "sphinx_design"
     );
     private static final List<String> MARKDOWN_EXTENSIONS = List.of(
             "myst_parser"

--- a/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/interceptors/DeprecatedInterceptor.java
+++ b/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/interceptors/DeprecatedInterceptor.java
@@ -7,7 +7,7 @@ package software.amazon.smithy.docgen.core.interceptors;
 
 import software.amazon.smithy.docgen.core.sections.ShapeSubheadingSection;
 import software.amazon.smithy.docgen.core.writers.DocWriter;
-import software.amazon.smithy.docgen.core.writers.DocWriter.AdmonitionType;
+import software.amazon.smithy.docgen.core.writers.DocWriter.NoticeType;
 import software.amazon.smithy.model.traits.DeprecatedTrait;
 import software.amazon.smithy.utils.CodeInterceptor;
 import software.amazon.smithy.utils.SmithyInternalApi;
@@ -31,7 +31,7 @@ public final class DeprecatedInterceptor implements CodeInterceptor<ShapeSubhead
     public void write(DocWriter writer, String previousText, ShapeSubheadingSection section) {
         var trait = section.shape().getMemberTrait(section.context().model(), DeprecatedTrait.class).get();
         writer.putContext("since", trait.getSince());
-        writer.openAdmonition(AdmonitionType.WARNING, w -> {
+        writer.openAdmonition(NoticeType.WARNING, w -> {
             w.write("Deprecated${?since} since ${since:L}${/since}");
         });
         writer.putContext("message", trait.getMessage());

--- a/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/interceptors/ExternalDocsInterceptor.java
+++ b/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/interceptors/ExternalDocsInterceptor.java
@@ -7,7 +7,7 @@ package software.amazon.smithy.docgen.core.interceptors;
 
 import software.amazon.smithy.docgen.core.sections.ShapeDetailsSection;
 import software.amazon.smithy.docgen.core.writers.DocWriter;
-import software.amazon.smithy.docgen.core.writers.DocWriter.AdmonitionType;
+import software.amazon.smithy.docgen.core.writers.DocWriter.NoticeType;
 import software.amazon.smithy.model.traits.ExternalDocumentationTrait;
 import software.amazon.smithy.utils.CodeInterceptor;
 import software.amazon.smithy.utils.Pair;
@@ -31,7 +31,7 @@ public final class ExternalDocsInterceptor implements CodeInterceptor<ShapeDetai
     @Override
     public void write(DocWriter writer, String previousText, ShapeDetailsSection section) {
         var trait = section.shape().getMemberTrait(section.context().model(), ExternalDocumentationTrait.class).get();
-        writer.openAdmonition(AdmonitionType.SEE_ALSO);
+        writer.openAdmonition(NoticeType.INFO);
         trait.getUrls().entrySet().stream()
                 .map(entry -> Pair.of(entry.getKey(), entry.getValue()))
                 .forEach(pair -> writer.write("$R\n", pair));

--- a/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/interceptors/HttpChecksumRequiredInterceptor.java
+++ b/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/interceptors/HttpChecksumRequiredInterceptor.java
@@ -7,7 +7,7 @@ package software.amazon.smithy.docgen.core.interceptors;
 
 import software.amazon.smithy.docgen.core.sections.ProtocolSection;
 import software.amazon.smithy.docgen.core.writers.DocWriter;
-import software.amazon.smithy.docgen.core.writers.DocWriter.AdmonitionType;
+import software.amazon.smithy.docgen.core.writers.DocWriter.NoticeType;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.traits.HttpChecksumRequiredTrait;
 import software.amazon.smithy.utils.Pair;
@@ -37,7 +37,7 @@ public final class HttpChecksumRequiredInterceptor extends ProtocolTraitIntercep
     @Override
     void write(DocWriter writer, String previousText, ProtocolSection section, HttpChecksumRequiredTrait trait) {
         writer.writeWithNoFormatting(previousText + "\n");
-        writer.openAdmonition(AdmonitionType.IMPORTANT);
+        writer.openAdmonition(NoticeType.IMPORTANT);
         writer.write("This operation REQUIRES a checksum, such as $R.", CONTENT_MD5);
         writer.closeAdmonition();
     }

--- a/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/interceptors/IdempotencyInterceptor.java
+++ b/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/interceptors/IdempotencyInterceptor.java
@@ -9,7 +9,7 @@ import java.util.Optional;
 import software.amazon.smithy.codegen.core.SymbolReference;
 import software.amazon.smithy.docgen.core.sections.ShapeDetailsSection;
 import software.amazon.smithy.docgen.core.writers.DocWriter;
-import software.amazon.smithy.docgen.core.writers.DocWriter.AdmonitionType;
+import software.amazon.smithy.docgen.core.writers.DocWriter.NoticeType;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.OperationIndex;
 import software.amazon.smithy.model.shapes.MemberShape;
@@ -75,7 +75,7 @@ public final class IdempotencyInterceptor implements CodeInterceptor<ShapeDetail
     @Override
     public void write(DocWriter writer, String previousText, ShapeDetailsSection section) {
         if (section.shape().isMemberShape()) {
-            writer.openAdmonition(AdmonitionType.NOTE);
+            writer.openAdmonition(NoticeType.NOTE);
             writer.write("""
                     This value will be used by the service to ensure the request is $R. \
                     Clients SHOULD automatically populate this (typically with a $R) if \
@@ -95,7 +95,7 @@ public final class IdempotencyInterceptor implements CodeInterceptor<ShapeDetail
                         .symbol(symbol)
                         .build());
         writer.putContext("token", idempotencyToken);
-        writer.openAdmonition(AdmonitionType.NOTE);
+        writer.openAdmonition(NoticeType.NOTE);
         writer.write("""
                 This operation is $R${?token} when the ${token:R} is set${/token}.
 

--- a/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/interceptors/InternalInterceptor.java
+++ b/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/interceptors/InternalInterceptor.java
@@ -8,7 +8,7 @@ package software.amazon.smithy.docgen.core.interceptors;
 import java.util.logging.Logger;
 import software.amazon.smithy.docgen.core.sections.ShapeSubheadingSection;
 import software.amazon.smithy.docgen.core.writers.DocWriter;
-import software.amazon.smithy.docgen.core.writers.DocWriter.AdmonitionType;
+import software.amazon.smithy.docgen.core.writers.DocWriter.NoticeType;
 import software.amazon.smithy.model.traits.InternalTrait;
 import software.amazon.smithy.utils.CodeInterceptor;
 import software.amazon.smithy.utils.SmithyInternalApi;
@@ -41,7 +41,7 @@ public final class InternalInterceptor implements CodeInterceptor<ShapeSubheadin
                 to filter out internal shapes: \
                 https://smithy.io/2.0/guides/building-models/build-config.html#excludeshapesbytrait""",
                 section.shape().getId()));
-        writer.openAdmonition(AdmonitionType.DANGER);
+        writer.openAdmonition(NoticeType.DANGER);
         writer.write("This is part of the internal API not available to external customers.");
         writer.closeAdmonition();
         writer.writeWithNoFormatting(previousText);

--- a/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/interceptors/NoReplaceInterceptor.java
+++ b/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/interceptors/NoReplaceInterceptor.java
@@ -9,7 +9,7 @@ import java.util.Optional;
 import software.amazon.smithy.codegen.core.SymbolReference;
 import software.amazon.smithy.docgen.core.DocGenerationContext;
 import software.amazon.smithy.docgen.core.writers.DocWriter;
-import software.amazon.smithy.docgen.core.writers.DocWriter.AdmonitionType;
+import software.amazon.smithy.docgen.core.writers.DocWriter.NoticeType;
 import software.amazon.smithy.model.knowledge.BottomUpIndex;
 import software.amazon.smithy.model.shapes.ResourceShape;
 import software.amazon.smithy.model.shapes.Shape;
@@ -52,7 +52,7 @@ abstract class NoReplaceInterceptor<S extends CodeSection> implements CodeInterc
                 .map(symbol -> SymbolReference.builder().alias("update lifecycle operation").symbol(symbol).build());
         writer.putContext("update", updateSymbolReference);
         writer.writeWithNoFormatting(previousText);
-        writer.openAdmonition(AdmonitionType.NOTE);
+        writer.openAdmonition(NoticeType.NOTE);
         writer.write("""
                 This operation cannot be used to update the $1R.\
                 ${?update} To update the $1R, use the ${update:R}.${/update}""",

--- a/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/interceptors/NullabilityInterceptor.java
+++ b/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/interceptors/NullabilityInterceptor.java
@@ -7,6 +7,7 @@ package software.amazon.smithy.docgen.core.interceptors;
 
 import software.amazon.smithy.docgen.core.sections.ShapeSubheadingSection;
 import software.amazon.smithy.docgen.core.writers.DocWriter;
+import software.amazon.smithy.docgen.core.writers.DocWriter.NoticeType;
 import software.amazon.smithy.model.knowledge.NullableIndex;
 import software.amazon.smithy.model.knowledge.NullableIndex.CheckMode;
 import software.amazon.smithy.utils.CodeInterceptor;
@@ -36,9 +37,7 @@ public final class NullabilityInterceptor implements CodeInterceptor<ShapeSubhea
 
     @Override
     public void write(DocWriter writer, String previousText, ShapeSubheadingSection section) {
-        writer.write("""
-                $B
-
-                $L""", "REQUIRED", previousText);
+        writer.writeBadge(NoticeType.WARNING, "REQUIRED")
+                .write("\n\n$L", previousText);
     }
 }

--- a/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/interceptors/OperationAuthInterceptor.java
+++ b/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/interceptors/OperationAuthInterceptor.java
@@ -9,7 +9,7 @@ import java.util.List;
 import software.amazon.smithy.docgen.core.DocgenUtils;
 import software.amazon.smithy.docgen.core.sections.ShapeDetailsSection;
 import software.amazon.smithy.docgen.core.writers.DocWriter;
-import software.amazon.smithy.docgen.core.writers.DocWriter.AdmonitionType;
+import software.amazon.smithy.docgen.core.writers.DocWriter.NoticeType;
 import software.amazon.smithy.model.knowledge.ServiceIndex;
 import software.amazon.smithy.model.knowledge.ServiceIndex.AuthSchemeMode;
 import software.amazon.smithy.model.shapes.ToShapeId;
@@ -51,7 +51,7 @@ public final class OperationAuthInterceptor implements CodeInterceptor<ShapeDeta
     @Override
     public void write(DocWriter writer, String previousText, ShapeDetailsSection section) {
         writer.writeWithNoFormatting(previousText);
-        writer.openAdmonition(AdmonitionType.IMPORTANT);
+        writer.openAdmonition(NoticeType.IMPORTANT);
 
         var index = ServiceIndex.of(section.context().model());
         var service = section.context().settings().service();

--- a/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/interceptors/PaginationInterceptor.java
+++ b/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/interceptors/PaginationInterceptor.java
@@ -8,7 +8,7 @@ package software.amazon.smithy.docgen.core.interceptors;
 import software.amazon.smithy.codegen.core.SymbolReference;
 import software.amazon.smithy.docgen.core.sections.ShapeDetailsSection;
 import software.amazon.smithy.docgen.core.writers.DocWriter;
-import software.amazon.smithy.docgen.core.writers.DocWriter.AdmonitionType;
+import software.amazon.smithy.docgen.core.writers.DocWriter.NoticeType;
 import software.amazon.smithy.model.knowledge.PaginatedIndex;
 import software.amazon.smithy.model.traits.PaginatedTrait;
 import software.amazon.smithy.utils.CodeInterceptor;
@@ -46,7 +46,7 @@ public final class PaginationInterceptor implements CodeInterceptor<ShapeDetails
                 .alias("output token")
                 .build());
 
-        writer.openAdmonition(AdmonitionType.IMPORTANT);
+        writer.openAdmonition(NoticeType.IMPORTANT);
         writer.write("""
                 This operation returns partial results in pages${?size}, whose maximum size may be
                 configured with ${size:R}${/size}. Each request may return an ${outputToken:R} that \

--- a/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/interceptors/RecommendedInterceptor.java
+++ b/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/interceptors/RecommendedInterceptor.java
@@ -7,6 +7,7 @@ package software.amazon.smithy.docgen.core.interceptors;
 
 import software.amazon.smithy.docgen.core.sections.ShapeSubheadingSection;
 import software.amazon.smithy.docgen.core.writers.DocWriter;
+import software.amazon.smithy.docgen.core.writers.DocWriter.NoticeType;
 import software.amazon.smithy.model.traits.RecommendedTrait;
 import software.amazon.smithy.utils.CodeInterceptor;
 import software.amazon.smithy.utils.SmithyInternalApi;
@@ -32,9 +33,10 @@ public final class RecommendedInterceptor  implements CodeInterceptor<ShapeSubhe
     public void write(DocWriter writer, String previousText, ShapeSubheadingSection section) {
         var trait = section.shape().expectTrait(RecommendedTrait.class);
         writer.putContext("reason", trait.getReason());
+        writer.writeBadge(NoticeType.IMPORTANT, "RECOMMENDED");
         writer.write("""
-                $B${?reason}: ${reason:L}${/reason}
+                ${?reason} ${reason:L}${/reason}
 
-                $L""", "RECOMMENDED", previousText);
+                $L""", previousText);
     }
 }

--- a/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/interceptors/RequestCompressionInterceptor.java
+++ b/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/interceptors/RequestCompressionInterceptor.java
@@ -8,7 +8,7 @@ package software.amazon.smithy.docgen.core.interceptors;
 import java.util.Optional;
 import software.amazon.smithy.docgen.core.sections.ShapeDetailsSection;
 import software.amazon.smithy.docgen.core.writers.DocWriter;
-import software.amazon.smithy.docgen.core.writers.DocWriter.AdmonitionType;
+import software.amazon.smithy.docgen.core.writers.DocWriter.NoticeType;
 import software.amazon.smithy.model.traits.RequestCompressionTrait;
 import software.amazon.smithy.utils.CodeInterceptor;
 import software.amazon.smithy.utils.SmithyInternalApi;
@@ -33,7 +33,7 @@ public final class RequestCompressionInterceptor implements CodeInterceptor<Shap
     @Override
     public void write(DocWriter writer, String previousText, ShapeDetailsSection section) {
         var trait = section.shape().expectTrait(RequestCompressionTrait.class);
-        writer.openAdmonition(AdmonitionType.IMPORTANT);
+        writer.openAdmonition(NoticeType.IMPORTANT);
 
         // Have particular support for single-element lists.
         writer.putContext("encoding", trait.getEncodings().size() == 1

--- a/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/interceptors/SensitiveInterceptor.java
+++ b/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/interceptors/SensitiveInterceptor.java
@@ -7,7 +7,7 @@ package software.amazon.smithy.docgen.core.interceptors;
 
 import software.amazon.smithy.docgen.core.sections.ShapeSubheadingSection;
 import software.amazon.smithy.docgen.core.writers.DocWriter;
-import software.amazon.smithy.docgen.core.writers.DocWriter.AdmonitionType;
+import software.amazon.smithy.docgen.core.writers.DocWriter.NoticeType;
 import software.amazon.smithy.model.traits.SensitiveTrait;
 import software.amazon.smithy.utils.CodeInterceptor;
 import software.amazon.smithy.utils.SmithyInternalApi;
@@ -31,7 +31,7 @@ public final class SensitiveInterceptor implements CodeInterceptor<ShapeSubheadi
 
     @Override
     public void write(DocWriter writer, String previousText, ShapeSubheadingSection section) {
-        writer.openAdmonition(AdmonitionType.DANGER);
+        writer.openAdmonition(NoticeType.DANGER);
         writer.write("""
                 The data this contains is sensitive and MUST be handled with care. \
                 It MUST NOT be exposed in things like exception messages or log \

--- a/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/interceptors/SinceInterceptor.java
+++ b/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/interceptors/SinceInterceptor.java
@@ -7,7 +7,7 @@ package software.amazon.smithy.docgen.core.interceptors;
 
 import software.amazon.smithy.docgen.core.sections.ShapeSubheadingSection;
 import software.amazon.smithy.docgen.core.writers.DocWriter;
-import software.amazon.smithy.docgen.core.writers.DocWriter.AdmonitionType;
+import software.amazon.smithy.docgen.core.writers.DocWriter.NoticeType;
 import software.amazon.smithy.model.traits.SinceTrait;
 import software.amazon.smithy.utils.CodeInterceptor;
 import software.amazon.smithy.utils.SmithyInternalApi;
@@ -32,7 +32,7 @@ public final class SinceInterceptor  implements CodeInterceptor<ShapeSubheadingS
     @Override
     public void write(DocWriter writer, String previousText, ShapeSubheadingSection section) {
         var trait = section.shape().getMemberTrait(section.context().model(), SinceTrait.class).get();
-        writer.openAdmonition(AdmonitionType.NOTE);
+        writer.openAdmonition(NoticeType.NOTE);
         writer.write("New in version $L.", trait.getValue());
         writer.closeAdmonition();
         writer.writeWithNoFormatting(previousText);

--- a/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/interceptors/SparseInterceptor.java
+++ b/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/interceptors/SparseInterceptor.java
@@ -8,7 +8,7 @@ package software.amazon.smithy.docgen.core.interceptors;
 import java.util.Locale;
 import software.amazon.smithy.docgen.core.sections.ShapeDetailsSection;
 import software.amazon.smithy.docgen.core.writers.DocWriter;
-import software.amazon.smithy.docgen.core.writers.DocWriter.AdmonitionType;
+import software.amazon.smithy.docgen.core.writers.DocWriter.NoticeType;
 import software.amazon.smithy.model.traits.SparseTrait;
 import software.amazon.smithy.utils.CodeInterceptor;
 import software.amazon.smithy.utils.SmithyInternalApi;
@@ -36,7 +36,7 @@ public final class SparseInterceptor implements CodeInterceptor<ShapeDetailsSect
                 ? section.context().model().expectShape(section.shape().asMemberShape().get().getTarget())
                 : section.shape();
         writer.writeWithNoFormatting(previousText);
-        writer.openAdmonition(AdmonitionType.NOTE);
+        writer.openAdmonition(NoticeType.NOTE);
         writer.write("This $L may contain null values.", target.getType().toString().toLowerCase(Locale.ENGLISH));
         writer.closeAdmonition();
     }

--- a/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/interceptors/UnstableInterceptor.java
+++ b/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/interceptors/UnstableInterceptor.java
@@ -7,7 +7,7 @@ package software.amazon.smithy.docgen.core.interceptors;
 
 import software.amazon.smithy.docgen.core.sections.ShapeSubheadingSection;
 import software.amazon.smithy.docgen.core.writers.DocWriter;
-import software.amazon.smithy.docgen.core.writers.DocWriter.AdmonitionType;
+import software.amazon.smithy.docgen.core.writers.DocWriter.NoticeType;
 import software.amazon.smithy.model.traits.UnstableTrait;
 import software.amazon.smithy.utils.CodeInterceptor;
 import software.amazon.smithy.utils.SmithyInternalApi;
@@ -30,7 +30,7 @@ public final class UnstableInterceptor implements CodeInterceptor<ShapeSubheadin
 
     @Override
     public void write(DocWriter writer, String previousText, ShapeSubheadingSection section) {
-        writer.openAdmonition(AdmonitionType.WARNING);
+        writer.openAdmonition(NoticeType.WARNING);
         writer.write("This is unstable or experimental and MAY change in the future.");
         writer.closeAdmonition();
         writer.writeWithNoFormatting(previousText);

--- a/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/interceptors/XmlAttributeInterceptor.java
+++ b/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/interceptors/XmlAttributeInterceptor.java
@@ -7,7 +7,7 @@ package software.amazon.smithy.docgen.core.interceptors;
 
 import software.amazon.smithy.docgen.core.sections.ProtocolSection;
 import software.amazon.smithy.docgen.core.writers.DocWriter;
-import software.amazon.smithy.docgen.core.writers.DocWriter.AdmonitionType;
+import software.amazon.smithy.docgen.core.writers.DocWriter.NoticeType;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.traits.XmlAttributeTrait;
 import software.amazon.smithy.utils.SmithyInternalApi;
@@ -32,7 +32,7 @@ public final class XmlAttributeInterceptor extends ProtocolTraitInterceptor<XmlA
     @Override
     void write(DocWriter writer, String previousText, ProtocolSection section, XmlAttributeTrait trait) {
         writer.writeWithNoFormatting(previousText + "\n");
-        writer.openAdmonition(AdmonitionType.IMPORTANT);
+        writer.openAdmonition(NoticeType.IMPORTANT);
         writer.write("This member represents an XML attribute rather than a nested tag.");
         writer.closeAdmonition();
     }

--- a/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/interceptors/XmlNamespaceInterceptor.java
+++ b/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/interceptors/XmlNamespaceInterceptor.java
@@ -7,7 +7,7 @@ package software.amazon.smithy.docgen.core.interceptors;
 
 import software.amazon.smithy.docgen.core.sections.ProtocolSection;
 import software.amazon.smithy.docgen.core.writers.DocWriter;
-import software.amazon.smithy.docgen.core.writers.DocWriter.AdmonitionType;
+import software.amazon.smithy.docgen.core.writers.DocWriter.NoticeType;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.traits.XmlNamespaceTrait;
 import software.amazon.smithy.utils.SmithyInternalApi;
@@ -37,7 +37,7 @@ public final class XmlNamespaceInterceptor extends ProtocolTraitInterceptor<XmlN
             namespace += ":" + trait.getPrefix().get();
         }
         namespace += "=\"" + trait.getUri() + "\"";
-        writer.openAdmonition(AdmonitionType.IMPORTANT);
+        writer.openAdmonition(NoticeType.IMPORTANT);
         writer.write("""
                 This tag must contain the following XML namespace $`
                 """, namespace);

--- a/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/writers/DocWriter.java
+++ b/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/writers/DocWriter.java
@@ -407,7 +407,7 @@ public abstract class DocWriter extends SymbolWriter<DocWriter, DocImportContain
      * @param titleWriter A consumer that writes out the title.
      * @return returns the writer.
      */
-    public abstract DocWriter openAdmonition(AdmonitionType type, Consumer<DocWriter> titleWriter);
+    public abstract DocWriter openAdmonition(NoticeType type, Consumer<DocWriter> titleWriter);
 
     /**
      * Opens an admonition with a default title.
@@ -419,7 +419,7 @@ public abstract class DocWriter extends SymbolWriter<DocWriter, DocImportContain
      * @param type The type of admonition to open.
      * @return returns the writer.
      */
-    public abstract DocWriter openAdmonition(AdmonitionType type);
+    public abstract DocWriter openAdmonition(NoticeType type);
 
     /**
      * Closes the body of an admonition.
@@ -429,30 +429,46 @@ public abstract class DocWriter extends SymbolWriter<DocWriter, DocImportContain
     public abstract DocWriter closeAdmonition();
 
     /**
+     * Writes text as a badge.
+     *
+     * <p>Implementations SHOULD write inline.
+     *
+     * <p>A badge in this context means text enclosed in a color-coded rectangular
+     * shape. The color should be based on the given type.
+     *
+     * @param type The notice type of the badge that determines styling.
+     * @param text The text to put in the badge.
+     * @return returns the writer.
+     */
+    public abstract DocWriter writeBadge(NoticeType type, String text);
+
+    /**
      * The type of admonition.
      *
      * <p>This affects the default title of the admonition, as well as styling.
      */
-    public enum AdmonitionType {
+    @SmithyUnstableApi
+    public enum NoticeType {
         /**
-         * An admonition that adds context without any strong severity.
+         * An notice that adds context without any strong severity.
          */
         NOTE,
 
         /**
-         * An admonition that adds context which is important, but not severely so.
+         * An notice that adds context which is important, but not severely so.
          */
         IMPORTANT,
 
         /**
-         * An admonition that adds context with strong severity.
+         * A notice that adds context with strong severity.
          *
-         * <p>This might be used by deprecation notices, for example.
+         * <p>This might be used by deprecation notices or required badges, for
+         * example.
          */
         WARNING,
 
         /**
-         * An admonition that adds context with extreme severity.
+         * A notice that adds context with extreme severity.
          *
          * <p>This might be used to add information about security-related concerns,
          * such as sensitive shapes and members.
@@ -460,8 +476,8 @@ public abstract class DocWriter extends SymbolWriter<DocWriter, DocImportContain
         DANGER,
 
         /**
-         * An admonition that refers to external context.
+         * A notice that refers to external context or highlights information.
          */
-        SEE_ALSO
+        INFO
     }
 }

--- a/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/writers/MarkdownWriter.java
+++ b/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/writers/MarkdownWriter.java
@@ -215,17 +215,17 @@ public class MarkdownWriter extends DocWriter {
     }
 
     @Override
-    public DocWriter openAdmonition(AdmonitionType type, Consumer<DocWriter> titleWriter) {
+    public DocWriter openAdmonition(NoticeType type, Consumer<DocWriter> titleWriter) {
         return writeInline("**$C:** ", titleWriter);
     }
 
     @Override
-    public DocWriter openAdmonition(AdmonitionType type) {
+    public DocWriter openAdmonition(NoticeType type) {
         return writeInline("**$L:** ", getAdmonitionName(type));
     }
 
-    private String getAdmonitionName(AdmonitionType type) {
-        if (type.equals(AdmonitionType.SEE_ALSO)) {
+    private String getAdmonitionName(NoticeType type) {
+        if (type.equals(NoticeType.INFO)) {
             return "See Also";
         }
         return type.toString();
@@ -234,5 +234,10 @@ public class MarkdownWriter extends DocWriter {
     @Override
     public DocWriter closeAdmonition() {
         return this;
+    }
+
+    @Override
+    public DocWriter writeBadge(NoticeType type, String text) {
+        return writeInline("`$L`", text);
     }
 }

--- a/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/writers/SphinxMarkdownWriter.java
+++ b/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/writers/SphinxMarkdownWriter.java
@@ -96,7 +96,7 @@ public final class SphinxMarkdownWriter extends MarkdownWriter {
     }
 
     @Override
-    public DocWriter openAdmonition(AdmonitionType type, Consumer<DocWriter> titleWriter) {
+    public DocWriter openAdmonition(NoticeType type, Consumer<DocWriter> titleWriter) {
         return write("""
                 :::{admonition} $C
                 :class: $L
@@ -105,12 +105,12 @@ public final class SphinxMarkdownWriter extends MarkdownWriter {
     }
 
     @Override
-    public DocWriter openAdmonition(AdmonitionType type) {
+    public DocWriter openAdmonition(NoticeType type) {
         return write(":::{$L}", getAdmonitionName(type));
     }
 
-    private String getAdmonitionName(AdmonitionType type) {
-        if (type.equals(AdmonitionType.SEE_ALSO)) {
+    private String getAdmonitionName(NoticeType type) {
+        if (type.equals(NoticeType.INFO)) {
             return "seealso";
         }
         return type.toString().toLowerCase(Locale.ENGLISH);
@@ -120,5 +120,18 @@ public final class SphinxMarkdownWriter extends MarkdownWriter {
     public DocWriter closeAdmonition() {
         write(":::");
         return this;
+    }
+
+    @Override
+    public DocWriter writeBadge(NoticeType type, String text) {
+        switch (type) {
+            case NOTE -> writeInline("{bdg-primary}");
+            case IMPORTANT -> writeInline("{bdg-success}");
+            case WARNING -> writeInline("{bdg-warning}");
+            case DANGER -> writeInline("{bdg-danger}");
+            case INFO -> writeInline("{bdg-info}");
+            default -> writeInline("{bdg}");
+        }
+        return writeInline("`$L`", text);
     }
 }


### PR DESCRIPTION
This updates required and recommended to use badges from [sphinx-design](https://sphinx-design.readthedocs.io/en/latest/badges_buttons.html). I changed the name of `AdmonitionType` to `NoticeType` since I'm sharing that between the two.

<img width="741" alt="Screenshot 2023-12-15 at 15 46 40" src="https://github.com/smithy-lang/smithy-docgen/assets/2643092/a855b7e2-8601-4125-abbe-e34f402caaa3">
<img width="484" alt="Screenshot 2023-12-15 at 15 47 22" src="https://github.com/smithy-lang/smithy-docgen/assets/2643092/1af9cfbc-6e8f-4b8c-a4f2-314926d9adac">

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.