### PR TITLE
Add in retryable badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,6 @@ which have default support.
   needed to make this feasible. Protocols will need to implement this also.
 * [mediaType](https://smithy.io/2.0/spec/protocol-traits.html#smithy-api-mediatype-trait)
 * [references](https://smithy.io/2.0/spec/resource-traits.html#smithy-api-references-trait)
-* [requestCompression](https://smithy.io/2.0/spec/behavior-traits.html#smithy-api-requestcompression-trait)
-* [retryable](https://smithy.io/2.0/spec/behavior-traits.html#smithy-api-retryable-trait)
 * [endpoint](https://smithy.io/2.0/spec/endpoint-traits.html)
 
 ## Security

--- a/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/integrations/BuiltinsIntegration.java
+++ b/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/integrations/BuiltinsIntegration.java
@@ -38,6 +38,7 @@ import software.amazon.smithy.docgen.core.interceptors.PatternInterceptor;
 import software.amazon.smithy.docgen.core.interceptors.RangeInterceptor;
 import software.amazon.smithy.docgen.core.interceptors.RecommendedInterceptor;
 import software.amazon.smithy.docgen.core.interceptors.RequestCompressionInterceptor;
+import software.amazon.smithy.docgen.core.interceptors.RetryableInterceptor;
 import software.amazon.smithy.docgen.core.interceptors.SensitiveInterceptor;
 import software.amazon.smithy.docgen.core.interceptors.SinceInterceptor;
 import software.amazon.smithy.docgen.core.interceptors.SparseInterceptor;
@@ -119,6 +120,7 @@ public class BuiltinsIntegration implements DocIntegration {
                 new ExternalDocsInterceptor(),
                 new IdempotencyInterceptor(),
                 new ErrorFaultInterceptor(),
+                new RetryableInterceptor(),
                 new DefaultValueInterceptor(),
                 new SinceInterceptor(),
                 new InternalInterceptor(),

--- a/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/interceptors/RetryableInterceptor.java
+++ b/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/interceptors/RetryableInterceptor.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.docgen.core.interceptors;
+
+import software.amazon.smithy.docgen.core.sections.ShapeSubheadingSection;
+import software.amazon.smithy.docgen.core.writers.DocWriter;
+import software.amazon.smithy.docgen.core.writers.DocWriter.NoticeType;
+import software.amazon.smithy.model.traits.RetryableTrait;
+import software.amazon.smithy.utils.CodeInterceptor;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+/**
+ * This adds badges and notices to errors that are retryable.
+ */
+@SmithyInternalApi
+public final class RetryableInterceptor implements CodeInterceptor.Prepender<ShapeSubheadingSection, DocWriter> {
+    @Override
+    public Class<ShapeSubheadingSection> sectionType() {
+        return ShapeSubheadingSection.class;
+    }
+
+    @Override
+    public boolean isIntercepted(ShapeSubheadingSection section) {
+        return section.shape().hasTrait(RetryableTrait.class);
+    }
+
+    @Override
+    public void prepend(DocWriter writer, ShapeSubheadingSection section) {
+        writer.writeBadge(NoticeType.IMPORTANT, "RETRYABLE").write("\n");
+        if (section.shape().expectTrait(RetryableTrait.class).getThrottling()) {
+            writer.openAdmonition(NoticeType.NOTE);
+            writer.write("""
+                    This is a throttling error. Request retries in response to this error should use exponential
+                    backoff with jitter. Clients should do this automatically.
+                    """);
+            writer.closeAdmonition();
+        }
+    }
+}

--- a/smithy-docgen-test/model/main.smithy
+++ b/smithy-docgen-test/model/main.smithy
@@ -359,7 +359,7 @@ operation BehaviorTraits with [AllAuth] {
 }
 
 /// An error that's explicitly retryable.
-@retryable
+@retryable(throttling: true)
 @error("server")
 @httpError(500)
 structure RetryableError with [ErrorMixin] {}


### PR DESCRIPTION
Adds a badge for retryable errors, and an info admonishment if it's a throttling error.

![Screenshot 2024-01-10 at 17 41 01](https://github.com/smithy-lang/smithy-docgen/assets/2643092/3e6d3f0f-73fa-4a5e-abdb-fff6df46fd86)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.