### PR TITLE
Add mediatype docs

### DIFF
--- a/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/integrations/BuiltinsIntegration.java
+++ b/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/integrations/BuiltinsIntegration.java
@@ -31,6 +31,7 @@ import software.amazon.smithy.docgen.core.interceptors.IdempotencyInterceptor;
 import software.amazon.smithy.docgen.core.interceptors.InternalInterceptor;
 import software.amazon.smithy.docgen.core.interceptors.JsonNameInterceptor;
 import software.amazon.smithy.docgen.core.interceptors.LengthInterceptor;
+import software.amazon.smithy.docgen.core.interceptors.MediaTypeInterceptor;
 import software.amazon.smithy.docgen.core.interceptors.NoReplaceBindingInterceptor;
 import software.amazon.smithy.docgen.core.interceptors.NoReplaceOperationInterceptor;
 import software.amazon.smithy.docgen.core.interceptors.NullabilityInterceptor;
@@ -92,6 +93,7 @@ public class BuiltinsIntegration implements DocIntegration {
         // the ones at the end will be at the top of the rendered pages. Therefore, interceptors
         // that provide more critical information should appear at the bottom of this list.
         return List.of(
+                new MediaTypeInterceptor(),
                 new OperationAuthInterceptor(),
                 new ApiKeyAuthInterceptor(),
                 new TimestampFormatInterceptor(),

--- a/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/interceptors/MediaTypeInterceptor.java
+++ b/smithy-docgen-core/src/main/java/software/amazon/smithy/docgen/core/interceptors/MediaTypeInterceptor.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.docgen.core.interceptors;
+
+import software.amazon.smithy.docgen.core.sections.ShapeSubheadingSection;
+import software.amazon.smithy.docgen.core.writers.DocWriter;
+import software.amazon.smithy.model.traits.MediaTypeTrait;
+import software.amazon.smithy.utils.CodeInterceptor;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+// TODO: Add content type to operation docs. Need a way to determine http protocols first.
+/**
+ * Adds the media type to member documentation if it has the
+ * <a href="https://smithy.io/2.0/spec/protocol-traits.html#smithy-api-mediatype-trait">
+ * mediaType</a> trait.
+ */
+@SmithyInternalApi
+public final class MediaTypeInterceptor implements CodeInterceptor.Prepender<ShapeSubheadingSection, DocWriter> {
+    @Override
+    public boolean isIntercepted(ShapeSubheadingSection section) {
+        return section.shape().getMemberTrait(section.context().model(), MediaTypeTrait.class).isPresent();
+    }
+
+    @Override
+    public Class<ShapeSubheadingSection> sectionType() {
+        return ShapeSubheadingSection.class;
+    }
+
+    @Override
+    public void prepend(DocWriter writer, ShapeSubheadingSection section) {
+        var trait = section.shape().getMemberTrait(section.context().model(), MediaTypeTrait.class).get();
+        writer.write("""
+                $B $`
+
+                """, "Media Type:", trait.getValue());
+    }
+}

--- a/smithy-docgen-test/model/main.smithy
+++ b/smithy-docgen-test/model/main.smithy
@@ -407,7 +407,7 @@ operation LimitedAuth {}
 operation LimitedOptionalAuth {}
 
 /// This operation showcases the various
-/// [serialization and protocol traits](https://smithy.io/2.0/spec/behavior-traits.html).
+/// [serialization and protocol traits](https://smithy.io/2.0/spec/protocol-traits.html).
 @http(method: "POST", uri: "/ProtocolTraits")
 operation ProtocolTraits with [AllAuth] {
     input := {
@@ -415,7 +415,7 @@ operation ProtocolTraits with [AllAuth] {
         @jsonName("spam")
         jsonName: String
 
-        /// This targets a shape with a media type. This trait is currently unuspported.
+        /// This targets a shape with a media type.
         mediaType: VideoData
 
         /// This is a timestamp with a custom format.


### PR DESCRIPTION
Adds media type to members (also theoretically shapes if we documented primitives). Does not add content type to operations because right now there's really no way to reliably know whether a protocol is HTTP or not.

<img width="347" alt="Screenshot 2024-01-12 at 16 06 00" src="https://github.com/smithy-lang/smithy-docgen/assets/2643092/f972f5d1-c5c4-4e28-82e2-1568a6b9ec19">

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.