### PR TITLE
Group up dependabot prs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,13 +5,28 @@ updates:
     schedule:
       interval: "weekly"
       day: "wednesday"
+    groups:
+      python:
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: "gradle"
     directory: "/"
     schedule:
       interval: "weekly"
       day: "wednesday"
+    groups:
+      gradle:
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
       day: "wednesday"
+    groups:
+      github:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
This groups up dependabot PRs that contain only minor/patch updates, per ecosystem. Major updates will still be separate PRs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.