### PR TITLE
Restrict workflow dependencies and permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,21 +6,27 @@ on:
   pull_request:
     branches: [main]
 
+permissions: # Default permissions restricted to read
+  contents: read
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}
     name: Java ${{ matrix.java }} ${{ matrix.os }}
+    permissions:
+      contents: read
+      checks: write
     strategy:
       matrix:
         java: [17]
         os: [macos-latest, ubuntu-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: gradle/wrapper-validation-action@v2
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: gradle/wrapper-validation-action@699bb18358f12c5b78b37bb0111d3a0e2276e0e2 # v2.1.1
 
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
         with:
           java-version: ${{ matrix.java }}
           distribution: 'corretto'
@@ -31,17 +37,20 @@ jobs:
   build-docs:
     runs-on: ubuntu-latest
     name: Test Documentation Build
+    permissions:
+      contents: read
+      checks: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
         with:
           java-version: 17
           distribution: 'corretto'
 
       - name: Set up Python 3.x
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
         with:
           python-version: '3.x'
 
@@ -49,13 +58,13 @@ jobs:
         run: ./gradlew clean build -Plog-tests
 
       - name: Upload built plain markdown test docs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         with:
           name: plain-markdown-docs
           path: smithy-docgen-test/build/smithyprojections/smithy-docgen-test/plain-markdown/docgen
 
       - name: Upload built sphinx markdown test docs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         with:
           name: sphinx-markdown-docs
           path: |


### PR DESCRIPTION
Locks down workflow permissions to read only by default and locks actions to specific hashes. Dependabot will handle notifying us of updates and making PRs for them.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.